### PR TITLE
Fix circle deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
   defaults: &defaults
-    working_directory: ~/bigtest
+    working_directory: ~/interactor
     docker:
       - image: circleci/node:8-browsers
 
@@ -9,7 +9,7 @@ references:
 
   attach_workspace: &attach_workspace
     attach_workspace:
-      at: ~/bigtest
+      at: ~/
 
 version: 2.0
 jobs:
@@ -23,22 +23,23 @@ jobs:
       - run:
           name: Install dependencies
           command: yarn
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - ./
       - save_cache:
           name: Save cache
           key: *cache_key
           paths:
             - node_modules
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - interactor
+            - .ssh
 
   lint:
     <<: *defaults
     steps:
       - *attach_workspace
       - run:
-          name: Lint packages
+          name: Lint package
           command: yarn lint
 
   build:
@@ -49,8 +50,13 @@ jobs:
           name: Build documentation
           command: yarn docs
       - run:
-          name: Build packages
+          name: Build package
           command: yarn build
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - interactor/dist
+            - interactor/docs
 
   test:
     <<: *defaults
@@ -71,10 +77,7 @@ jobs:
             npx bigtest-release --access=public
       - run:
           name: Push Tags
-          command: |
-            mkdir -p ~/.ssh
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-            git push --tags
+          command: git push --tags
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- deployment issues
+
 ## [0.4.0] - 2018-04-07
 
 ### Added


### PR DESCRIPTION
## Purpose

Currently, the `build` step does not persist anything to the workspace. So when the `deploy` step attaches the workspace, it does not include the `dist` directory.

## Approach

The `build` job should persist `dist` and `docs` to the workspace

The `~/.ssh` directory is also persisted during the `install` job to avoid having to set it up again later for github authentication.

#### TODOs

- Release a new version of this package so NPM can receive the right files.
- We should add a `files` field to the `package.json` before releasing to better control which files NPM includes. By doing this we'll also be able to remove the empty `.npmignore` file from the repo.
- This should be done to all the `@bigtest/*` repos. Maybe `@bigtest/meta` can have a command that will simply copy a config template so when that is updated, we can just run a command in the other repos to update them more quickly than copy-pasting the config between the repos.