### PR TITLE
Add ES Module bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- transpiled es module bundle
+
 ### Changed
 
 - providing a `parent` to an interactor will return a modified

--- a/package.json
+++ b/package.json
@@ -6,17 +6,19 @@
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/index.js",
   "module": "src/index.js",
+  "files": [
+    "dist",
+    "docs",
+    "src"
+  ],
   "scripts": {
     "build": "rollup --config",
-    "start": "karma start",
-    "test": "karma start --single-run",
-    "postpublish": "bigtest-tag-version",
     "docs": "bigtest-docs",
-    "lint": "eslint ./"
+    "lint": "eslint --ignore-path .gitignore ./",
+    "postpublish": "bigtest-tag-version",
+    "start": "karma start",
+    "test": "karma start --single-run"
   },
-  "eslintIgnore": [
-    "/dist/"
-  ],
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.0",
     "@babel/polyfill": "^7.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.4.0",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
-  "main": "dist/index.js",
-  "module": "src/index.js",
+  "main": "dist/umd/index.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist",
     "docs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,17 @@
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
+import pkg from './package.json';
 
 export default {
   input: 'src/index.js',
-  output: {
-    file: 'dist/index.js',
+  output: [{
     format: 'umd',
-    name: 'BigTest.Interaction'
-  },
+    name: 'BigTest.Interactor',
+    file: pkg.main
+  }, {
+    format: 'es',
+    file: pkg.module
+  }],
   plugins: [
     resolve(),
     babel({

--- a/src/interactions/index.js
+++ b/src/interactions/index.js
@@ -1,38 +1,3 @@
-import { find } from './find';
-import { findAll } from './find-all';
-import { click } from './clickable';
-import { fill } from './fillable';
-import { focus } from './focusable';
-import { blur } from './blurrable';
-import { trigger } from './triggerable';
-import { scroll } from './scrollable';
-import { text } from './text';
-import { value } from './value';
-import { isVisible } from './is-visible';
-import { isHidden } from './is-hidden';
-import { isPresent } from './is-present';
-
-// interaction methods
-export const methods = {
-  find,
-  findAll,
-  click,
-  fill,
-  focus,
-  blur,
-  trigger,
-  scroll
-};
-
-// interaction properties
-export const properties = {
-  text,
-  value,
-  isVisible,
-  isHidden,
-  isPresent
-};
-
 // interaction creators
 export { default as clickable } from './clickable';
 export { default as fillable } from './fillable';

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -1,7 +1,19 @@
 /* global Element */
 import Convergence from '@bigtest/convergence';
 import { $, $$, isInteractor, getMethodNames } from './utils';
-import { methods, properties } from './interactions';
+import { find } from './interactions/find';
+import { findAll } from './interactions/find-all';
+import { click } from './interactions/clickable';
+import { fill } from './interactions/fillable';
+import { focus } from './interactions/focusable';
+import { blur } from './interactions/blurrable';
+import { trigger } from './interactions/triggerable';
+import { scroll } from './interactions/scrollable';
+import { text } from './interactions/text';
+import { value } from './interactions/value';
+import { isVisible } from './interactions/is-visible';
+import { isHidden } from './interactions/is-hidden';
+import { isPresent } from './interactions/is-present';
 
 /**
  * ``` javascript
@@ -235,15 +247,34 @@ Object.defineProperties(Interactor, {
 // default interaction methods
 Object.defineProperties(
   Interactor.prototype,
-  Object.entries(methods).reduce((descriptors, [name, method]) => {
-    return Object.assign(descriptors, { [name]: { value: method } });
+  Object.entries({
+    find,
+    findAll,
+    click,
+    fill,
+    focus,
+    blur,
+    trigger,
+    scroll
+  }).reduce((descriptors, [name, method]) => {
+    return Object.assign(descriptors, {
+      [name]: { value: method }
+    });
   }, {})
 );
 
 // default interaction properties
 Object.defineProperties(
   Interactor.prototype,
-  Object.entries(properties).reduce((descriptors, [name, getter]) => {
-    return Object.assign(descriptors, { [name]: { get: getter } });
+  Object.entries({
+    text,
+    value,
+    isVisible,
+    isHidden,
+    isPresent
+  }).reduce((descriptors, [name, getter]) => {
+    return Object.assign(descriptors, {
+      [name]: { get: getter }
+    });
   }, {})
 );

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../.eslintrc.json",
   "rules": {
     "no-return-assign": 0,
     "no-unused-expressions": 0


### PR DESCRIPTION
## Purpose

This fixes #6. Previously, we were using rollup to compile and bundle our files. ~Since this package is not meant to be directly referenced in a `script` tag, we have no need to bundle our files.~ Since we were using rollup, it's pretty trivial to add another output option to have it create a ESM bundle for us.

## Approach

~Remove the rollup bundler and replace the `build` command with `babel-cli`. Also added a `.babelrc` to hold our babel config.~

~Since this package is also not meant to be used in a node environment, `main` was removed from `package.json`.~

Simply added another output object to the rollup config file for ESM bundles.

I added a `files` key to explicitly specify which files to include with the NPM package. And I also cleaned up the `lint` command a bit by using `.gitignore` instead of `eslintIgnore` and removing the unnecessary `extends` in the `tests` directory. ESLint will automatically extend any config specified in parent directories.

Finally, while inspecting the build outputs, I noticed that we were exporting two objects that should only be used internally. I removed those exports from `src/interactions/index.js` and imported everything individually into `src/interactor.js` which is where they were being used.