### PR TITLE
Change how interactors handle nested relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- providing a `parent` to an interactor will return a modified
+  instance that contains wrapped methods to append new instances to
+  the `parent` interactor
+
 ### Fixed
 
 - deployment issues
+- nested interactors incorrectly returned a parent instance within
+  complex interaction methods which caused errors
 
 ## [0.4.0] - 2018-04-07
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,3 +95,27 @@ export function isPropertyDescriptor(descr) {
     Object.hasOwnProperty.call(descr, 'enumerable') &&
     Object.hasOwnProperty.call(descr, 'configurable');
 }
+
+/**
+ * Returns an array of all method names found on an object including
+ * any inherited methods (not including Object.prototype).
+ *
+ * @private
+ * @param {Object} instance - Instance to find methods for
+ * @returns {String[]} Array of method names
+ */
+export function getMethodNames(instance) {
+  let proto = Object.getPrototypeOf(instance);
+  let descr = {};
+
+  while (proto && proto !== Object.prototype) {
+    // uses descriptors to avoid invoking getters when filtering
+    descr = Object.assign({}, Object.getOwnPropertyDescriptors(proto), descr);
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return Object.keys(descr).filter(name => {
+    return name !== 'constructor' &&
+      typeof descr[name].value === 'function';
+  });
+}

--- a/tests/decorator-test.js
+++ b/tests/decorator-test.js
@@ -16,9 +16,7 @@ describe('BigTest Interaction: decorator', () => {
           value() {}
         };
 
-        this.nested = new (interactor(function() {
-          this.deep = new Interactor();
-        }))();
+        this.nested = new Interactor();
       }
 
       get getter() {
@@ -50,16 +48,10 @@ describe('BigTest Interaction: decorator', () => {
     expect(new TestInteractor()).to.respondTo('test');
   });
 
-  it('returns a new parent instance from nested interactor methods', () => {
+  it('attaches a parent to nested interactors', () => {
     expect(new TestInteractor().nested).to.be.an.instanceOf(Interactor);
     expect(new TestInteractor().nested).to.not.be.an.instanceOf(TestInteractor);
-    expect(new TestInteractor().nested.do(() => {})).to.be.an.instanceOf(TestInteractor);
-  });
-
-  it('returns a new parent instance from deeply nested interactor methods', () => {
-    expect(new TestInteractor().nested.deep).to.be.an.instanceOf(Interactor);
-    expect(new TestInteractor().nested.deep).to.not.be.an.instanceOf(TestInteractor);
-    expect(new TestInteractor().nested.deep.do(() => {})).to.be.an.instanceOf(TestInteractor);
+    expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
   });
 
   it('throws an error when attempting to redefine existing properties', () => {

--- a/tests/interactor-test.js
+++ b/tests/interactor-test.js
@@ -81,6 +81,67 @@ describe('BigTest Interaction: Interactor', () => {
     });
   });
 
+  describe('with a parent', () => {
+    let child;
+
+    class ParentInteractor extends Interactor {}
+    class ChildInteractor extends Interactor {
+      test1() { return this.do(() => {}); }
+      test2() { return this.test1().test1(); }
+      test3() { return instance; }
+    }
+
+    beforeEach(() => {
+      child = new ChildInteractor({
+        parent: new ParentInteractor()
+      });
+    });
+
+    it('is an instance of the current interactor', () => {
+      expect(child).to.be.an.instanceof(ChildInteractor);
+    });
+
+    it('contains a reference to the parent instance', () => {
+      expect(child.parent).to.be.an.instanceof(ParentInteractor);
+    });
+
+    it('returns a new parent instance from methods', () => {
+      expect(child.test1()).to.be.an.instanceof(ParentInteractor);
+    });
+
+    it('returns a new parent instance from complex methods', () => {
+      expect(child.test2()).to.be.an.instanceof(ParentInteractor);
+    });
+
+    it('does not return a new parent when a new child is not returned', () => {
+      expect(child.test3()).to.not.be.an.instanceof(ChildInteractor);
+      expect(child.test3()).to.not.be.an.instanceof(ParentInteractor);
+    });
+
+    describe('and deeply nested', () => {
+      let deep;
+
+      class DeepInteractor extends Interactor {
+        test() { return this.do(() => {}); }
+      }
+
+      beforeEach(() => {
+        deep = new DeepInteractor({
+          parent: child
+        });
+      });
+
+      it('contains a reference to the immediate parent', () => {
+        expect(deep.parent).to.be.an.instanceof(ChildInteractor);
+        expect(deep.parent.parent).to.be.an.instanceof(ParentInteractor);
+      });
+
+      it('returns a new instance of the topmost parent from methods', () => {
+        expect(deep.test()).to.be.an.instanceof(ParentInteractor);
+      });
+    });
+  });
+
   describe('DOM helpers', () => {
     useFixture('find-fixture');
 


### PR DESCRIPTION
## Purpose

Fixes #9. Previously, when a parent was provided and a new instance was created from an existing instance, the constructor returned a new instance of the parent. This caused issues with complex interaction methods that reference other methods of the current interactor.

For example:

```js
@interactor class ChildInteractor {
  someAction = action(...);
  complexAction() {
    return this
      .click(...)
      .someAction(...)
  }
}

@interactor class ParentInteractor {
  child = new ChildInteractor()
}
```

Using the example above, `new ParentInteractor().child.complexAction()` will throw an error because `click(...)` returns an instance of `PageInteractor` which does not specify `someAction`.

## Approach

Instead of returning a parent instance in the constructor after a new instance is created, when `parent` is provided to an interactor the methods are wrapped to return parent instances _after_ they have been called.

Doing it this way is no different than:

```js
new PageInteractor()
  .append(new CustomInteractor().complexAction())
```

But it is done for us automatically when providing a `parent` option.