### PR TITLE
Fix `is` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.4.2] - 2018-04-30
+
 ### Fixed
 
 - `is` property when selector is omitted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- `is` property when selector is omitted
+
 ## [0.4.1] - 2018-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/interactions/is.js
+++ b/src/interactions/is.js
@@ -49,6 +49,11 @@ function elementMatches($el, selector) {
  * @returns {Object} Property descriptor
  */
 export default function(selector, match) {
+  if (!match) {
+    match = selector;
+    selector = null;
+  }
+
   return computed(function() {
     return elementMatches(this.$(selector), match);
   });

--- a/tests/fixtures/is-fixture.html
+++ b/tests/fixtures/is-fixture.html
@@ -1,5 +1,4 @@
-<p class="test-p" data-test></p>
-
-<div id="scoped">
+<div id="scoped" data-root>
+  <p class="test-p" data-test></p>
   <p class="test-p"></p>
 </div>

--- a/tests/interactions/is-test.js
+++ b/tests/interactions/is-test.js
@@ -4,7 +4,9 @@ import { useFixture } from '../helpers';
 import { interactor, is } from '../../src';
 
 const IsInteractor = interactor(function() {
-  this.isTest = is('.test-p', '[data-test]');
+  this.isRoot = is('[data-root]');
+  this.testFirst = is('.test-p:first-child', '[data-test]');
+  this.testLast = is('.test-p:last-child', '[data-test]');
 });
 
 describe('BigTest Interaction: is', () => {
@@ -13,19 +15,20 @@ describe('BigTest Interaction: is', () => {
   useFixture('is-fixture');
 
   beforeEach(() => {
-    test = new IsInteractor();
-  });
-
-  it('has an is property', () => {
-    expect(test).to.have.property('isTest').that.is.a('boolean');
-  });
-
-  it('returns true if the element matches the selector', () => {
-    expect(test.isTest).to.be.true;
-  });
-
-  it('returns false if the element does not match the selector', () => {
     test = new IsInteractor('#scoped');
-    expect(test.isTest).to.be.false;
+  });
+
+  it('has is properties', () => {
+    expect(test).to.have.property('isRoot').that.is.a('boolean');
+    expect(test).to.have.property('testFirst').that.is.a('boolean');
+  });
+
+  it('returns true if the selector matches', () => {
+    expect(test.isRoot).to.be.true;
+    expect(test.testFirst).to.be.true;
+  });
+
+  it('returns false if the selector does not match', () => {
+    expect(test.testLast).to.be.false;
   });
 });


### PR DESCRIPTION
## Purpose

When omitting the `selector` argument, the `is` property incorrectly still used the first argument as the `selector`.

The issue was discovered while upgrading `@bigtest/interactor` [here](https://github.com/folio-org/ui-eholdings/pull/376#discussion_r185061478).

## Approach

When `selector` is not provided (and only one argument is), the `selector` should default to `null` so that `this.$()` will return the root element for matching.

Incremented the version to release this immediately so that linked PR can be merged.