### PR TITLE
Update Interactor docs formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.4.3] - 2018-05-05
+
+### Changed
+
+- escaped decorator documentation and updated documentation tags for
+  more accurate output
+
 ## [0.4.2] - 2018-04-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/polyfill": "^7.0.0-beta.0",
     "@babel/preset-env": "^7.0.0-beta.0",
     "@babel/register": "^7.0.0-beta.0",
-    "@bigtest/meta": "bigtestjs/meta",
+    "@bigtest/meta": "bigtestjs/meta#v0.0.1",
     "babel-loader": "8.0.0-beta.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -18,7 +18,7 @@ import { isInteractor, isPropertyDescriptor } from './utils';
  *   clickable
  * } from '@bigtest/interactor';
  *
- * @interactor class CustomInteractor {
+ * \@interactor class CustomInteractor {
  *   // optional default scope for this interactor
  *   static defaultScope = '#some-element'
  *

--- a/src/interactions/attribute.js
+++ b/src/interactions/attribute.js
@@ -13,7 +13,7 @@ import { computed } from './helpers';
  * ```
  *
  * ``` javascript
- * @interactor class CardInteractor {
+ * \@interactor class CardInteractor {
  *   id = attribute('id')
  *   url = attribute('.card-link', 'href')
  * }

--- a/src/interactions/blurrable.js
+++ b/src/interactions/blurrable.js
@@ -17,8 +17,7 @@ import { action } from './helpers';
  * await new Interactor('form').blur('input[type="email"]')
  * ```
  *
- * @method blur
- * @memberOf Interactor
+ * @method Interactor#blur
  * @param {String} [selector] - Nested element query selector
  * @returns {Interactor} A new instance with additional convergences
  */
@@ -46,7 +45,7 @@ export function blur(selector) {
  * ```
  *
  * ``` javascript
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   blurEmail = blurrable('input[type="email"]')
  * }
  * ```

--- a/src/interactions/clickable.js
+++ b/src/interactions/clickable.js
@@ -18,8 +18,7 @@ import { action } from './helpers';
  * await new Interactor('form').click('[type="submit"]')
  * ```
  *
- * @method click
- * @memberOf Interactor
+ * @method Interactor#click
  * @param {String} [selector] - Nested element query selector
  * @returns {Interactor} A new instance with additional convergences
  */
@@ -42,7 +41,7 @@ export function click(selector) {
  * ```
  *
  * ``` javascript
- * @interactor class CardInteractor {
+ * \@interactor class CardInteractor {
  *   clickThrough = clickable('.card-link')
  * }
  * ```

--- a/src/interactions/collection.js
+++ b/src/interactions/collection.js
@@ -15,7 +15,7 @@ import interactor from '../decorator';
  * ```
 
  * ``` javascript
- * @interactor class CheckboxGroupInteractor {
+ * \@interactor class CheckboxGroupInteractor {
  *   items = collection('input[type="checkbox"]')
  * }
  * ```
@@ -59,7 +59,7 @@ import interactor from '../decorator';
  * ```
  *
  * ``` javascript
- * @interactor class CardsListInteractor {
+ * \@interactor class CardsListInteractor {
  *   cards = collection('.card', {
  *     clickThrough: clickable('.card-link')
  *   })
@@ -69,11 +69,11 @@ import interactor from '../decorator';
  * You can also use another interactor class.
  *
  * ``` javascript
- * @interactor class CardInteractor {
+ * \@interactor class CardInteractor {
  *   clickThrough = clickable('.card-link')
  * }
  *
- * @interactor class CardsListInteractor {
+ * \@interactor class CardsListInteractor {
  *   cards = collection('.card', CardInteractor)
  * }
  * ```

--- a/src/interactions/fillable.js
+++ b/src/interactions/fillable.js
@@ -18,8 +18,7 @@ import { action } from './helpers';
  * await new Interactor('form').fill('input#name', 'value')
  * ```
  *
- * @method fill
- * @memberOf Interactor
+ * @method Interactor#fill
  * @param {String} [selector] - Nested element query selector
  * @param {String} value - Value to set
  * @returns {Interactor} A new instance with additional convergences
@@ -84,7 +83,7 @@ export function fill(selectorOrValue, value) {
  * ```
  *
  * ``` javascript
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   fillName = fillable('input#name')
  * }
  * ```

--- a/src/interactions/find-all.js
+++ b/src/interactions/find-all.js
@@ -9,8 +9,7 @@ import { computed } from './helpers';
  * let $listItems = await new Interactor('ul').findAll('li')
  * ```
  *
- * @method findAll
- * @memberOf Interactor
+ * @method Interactor#findAll
  * @param {String} selector - Element query selector
  * @returns {Interactor} A new instance with additional convergences
  */
@@ -25,7 +24,7 @@ export function findAll(selector) {
  * custom interactor class.
  *
  * ``` javascript
- * @interactor class ListInteractor {
+ * \@interactor class ListInteractor {
  *   getItems = findAll('li')
  * }
  * ```

--- a/src/interactions/find.js
+++ b/src/interactions/find.js
@@ -7,8 +7,7 @@ import { computed } from './helpers';
  * let $el = await new Interactor().find('.some-element')
  * ```
  *
- * @method find
- * @memberOf Interactor
+ * @method Interactor#find
  * @param {String} selector - Element query selector
  * @returns {Interactor} A new instance with additional convergences
  */
@@ -23,7 +22,7 @@ export function find(selector) {
  * interactor class.
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   getHeading = find('h1.heading')
  * }
  * ```

--- a/src/interactions/focusable.js
+++ b/src/interactions/focusable.js
@@ -17,8 +17,7 @@ import { action } from './helpers';
  * await new Interactor('form').focus('input[type="email"]')
  * ```
  *
- * @method focus
- * @memberOf Interactor
+ * @method Interactor#focus
  * @param {String} selector - Nested element query selector
  * @returns {Interactor} A new instance with additional convergences
  */
@@ -46,7 +45,7 @@ export function focus(selector) {
  * ```
  *
  * ``` javascript
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   focusEmail = focusable('input[type="email"]')
  * }
  * ```

--- a/src/interactions/has-class.js
+++ b/src/interactions/has-class.js
@@ -12,7 +12,7 @@ import { computed } from './helpers';
  * ```
  *
  * ``` javascript
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   hasErrors = hasClass('error')
  *   hasNameError = hasClass('input#name', 'error')
  *   hasEmailError = hasClass('input#email', 'error')

--- a/src/interactions/helpers.js
+++ b/src/interactions/helpers.js
@@ -10,7 +10,7 @@
  * ```
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   username = data('user', '#user-info')
  * }
  * ```
@@ -39,7 +39,7 @@ export function computed(getter) {
  * ```
  *
  * ``` javascript
- * @interactor class CheckboxGroupInteractor {
+ * \@interactor class CheckboxGroupInteractor {
  *   check = check('input[type="checkbox"]')
  * }
  * ```

--- a/src/interactions/is-hidden.js
+++ b/src/interactions/is-hidden.js
@@ -23,8 +23,7 @@ import { computed } from './helpers';
  * SVG elements that do not render anything themselves, `display:
  * none` elements, and generally any elements that are not rendered.
  *
- * @member {Boolean} isHidden
- * @memberOf Interactor
+ * @member {Boolean} Interactor#isHidden
  * @throws {Error} When the interactor scope cannot be found
  */
 export function isHidden() {
@@ -45,7 +44,7 @@ export function isHidden() {
  * ```
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   isFooHidden = isHidden('#foo')
  *   isBarHidden = isHidden('#bar')
  * }

--- a/src/interactions/is-present.js
+++ b/src/interactions/is-present.js
@@ -15,8 +15,7 @@ import { computed } from './helpers';
  * new Interactor('#bar').isPresent //=> false
  * ```
  *
- * @member {Boolean} isPresent
- * @memberOf Interactor
+ * @member {Boolean} Interactor#isPresent
  */
 export function isPresent() {
   try {
@@ -38,7 +37,7 @@ export function isPresent() {
  * ```
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   isFooPresent = isPresent('#foo')
  *   isBarPresent = isPresent('#bar')
  * }

--- a/src/interactions/is-visible.js
+++ b/src/interactions/is-visible.js
@@ -23,8 +23,7 @@ import { computed } from './helpers';
  * SVG elements that do not render anything themselves, `display:
  * none` elements, and generally any elements that are not rendered.
  *
- * @member {Boolean} isVisible
- * @memberOf Interactor
+ * @member {Boolean} Interactor#isVisible
  * @throws {Error} When the interactor scope cannot be found
  */
 export function isVisible() {
@@ -45,7 +44,7 @@ export function isVisible() {
  * ```
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   isFooVisible = isVisible('#foo')
  *   isBarVisible = isVisible('#bar')
  * }

--- a/src/interactions/is.js
+++ b/src/interactions/is.js
@@ -30,7 +30,7 @@ function elementMatches($el, selector) {
  * ```
  *
  * ``` javascript
- * @interactor class ListInteractor {
+ * \@interactor class ListInteractor {
  *   isList = is('.list')
  *   isFooFirst = is('#foo', ':first-child')
  *   isBarLast = is('#bar', ':last-child')

--- a/src/interactions/property.js
+++ b/src/interactions/property.js
@@ -13,7 +13,7 @@ import { computed } from './helpers';
  * ```
  *
  * ``` javascript
- * @interactor class CardInteractor {
+ * \@interactor class CardInteractor {
  *   height = property('offsetHeight')
  *   isDisabled = property('button.card-cta', 'disabled')
  * }

--- a/src/interactions/scrollable.js
+++ b/src/interactions/scrollable.js
@@ -11,8 +11,7 @@ import { action } from './helpers';
  * await new Interaction('#page').scroll('.nested-view', { left: 100 })
  * ```
  *
- * @method scroll
- * @memberOf Interactor
+ * @method Interactor#scroll
  * @param {String} [selector] - Nested element query selector
  * @param {Number} scrollTo.top - Number of pixels to scroll the top-offset
  * @param {Number} scrollTo.left - Number of pixels to scroll the left-offset
@@ -53,7 +52,7 @@ export function scroll(selectorOrScrollTo, scrollTo) {
  * custom interactor class.
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   scrollSection = scrollable('.scrollview')
  * }
  * ```

--- a/src/interactions/text.js
+++ b/src/interactions/text.js
@@ -33,8 +33,7 @@ function getText($el) {
  * new Interactor('p').text //=> "Hello World!"
  * ```
  *
- * @member {Boolean} text
- * @memberOf Interactor
+ * @member {Boolean} Interactor#text
  * @throws {Error} When the interactor scope cannot be found
  */
 export function text() {
@@ -52,7 +51,7 @@ export function text() {
  * ```
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   heading = text('h1')
  * }
  * ```

--- a/src/interactions/triggerable.js
+++ b/src/interactions/triggerable.js
@@ -44,6 +44,7 @@ function getTriggerArgs(args) {
  * await new Interactor('#foo').trigger('#bar', 'customEvent', { ... })
  * ```
  *
+ * @method Interactor#trigger
  * @param {String} [selector] - Nested element query selector
  * @param {String} eventName - Event name or options object
  * @param {Object} [options] - Event init options
@@ -76,7 +77,7 @@ export function trigger(...args) {
  * within a custom interactor class.
  *
  * ``` javascript
- * @interactor class PageInteractor {
+ * \@interactor class PageInteractor {
  *   triggerEvent = triggerable('customEvent', { ... })
  *   triggerFooEvent = triggerable('#foo', 'customEvent')
  * }
@@ -89,6 +90,7 @@ export function trigger(...args) {
  * await new PageInteractor().triggerFooEvent({ ... })
  * ```
  *
+ * @function triggerable
  * @param {String} [selector] - Element query selector
  * @param {String} eventName - Event name or options object
  * @param {Object} [options] - Event init options

--- a/src/interactions/value.js
+++ b/src/interactions/value.js
@@ -11,8 +11,7 @@ import { computed } from './helpers';
  * new Interactor('input').value //=> "Hello World!"
  * ```
  *
- * @member {Boolean} value
- * @memberOf Interactor
+ * @member {Boolean} Interactor#value
  * @throws {Error} When the interactor scope cannot be found
  */
 export function value() {
@@ -30,7 +29,7 @@ export function value() {
  * ```
  *
  * ``` javascript
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   name = value('input#name')
  * }
  * ```

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -88,7 +88,7 @@ import { isPresent } from './interactions/is-present';
  * ``` javascript
  * import { interactor, fillable, clickable } from '@bigtest/interaction'
  *
- * @interactor class FormInteractor {
+ * \@interactor class FormInteractor {
  *   fillEmail = fillable('input[type="email"]')
  *   submit = clickable('button[type="submit"]')
  *
@@ -100,7 +100,7 @@ import { isPresent } from './interactions/is-present';
  * }
  * ```
  */
-export default class Interactor extends Convergence {
+class Interactor extends Convergence {
   /**
    * The constructor arguments mimic convergence constructor arguments
    * in that new instances receive new `options` in addition to the
@@ -237,8 +237,7 @@ Object.defineProperties(Interactor, {
    * ```
    *
    * @static
-   * @member {String|Element} defaultScope
-   * @alias Interactor.defaultScope
+   * @member {String|Element} Interactor.defaultScope
    * @default document.body
    */
   defaultScope: { value: document.body }
@@ -278,3 +277,5 @@ Object.defineProperties(
     });
   }, {})
 );
+
+export default Interactor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,11 +521,12 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.7.0.tgz#df577d7e78b453cf80b4f29acf66dd7f60fcc0c1"
 
-"@bigtest/meta@bigtestjs/meta":
+"@bigtest/meta@bigtestjs/meta#v0.0.1":
   version "0.0.1"
-  resolved "https://codeload.github.com/bigtestjs/meta/tar.gz/4c411a5601ed81e9d44a879234a77e33557b1b79"
+  resolved "https://codeload.github.com/bigtestjs/meta/tar.gz/30e11077a43a8edb0000b7ba805026726e9bf9df"
   dependencies:
     jsdoc-api "^4.0.3"
+    jsdoc-escape-at "^1.0.1"
 
 JSONStream@^1.0.3:
   version "1.3.2"
@@ -3320,6 +3321,10 @@ jsdoc-api@^4.0.3:
     object-to-spawn-args "^1.1.1"
     temp-path "^1.0.0"
     walk-back "^3.0.0"
+
+jsdoc-escape-at@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-escape-at/-/jsdoc-escape-at-1.0.1.tgz#a1264683a32f3e03a589c85d6e92769718c7ab90"
 
 jsdoc@~3.5.5:
   version "3.5.5"


### PR DESCRIPTION
## Purpose

To improve the doc output for the BigTest documentation site. 

## Approach

A lot of the docs were broken because of `@interactor` in the doc comment. JSDoc was trying to use that as a tag rather than knowing it was a decorator. We fixed that partially in https://github.com/bigtestjs/meta/pull/7 by including a plugin. But we still have to escape every instance of `@interactor: 
```js
\@interactor
```
Then we cleaned up some tags so the generator knew what to do with them.

## GIF
![2018-05-04 18 06 46](https://user-images.githubusercontent.com/2072894/39656512-0fb7549e-4fc6-11e8-9181-f12c3d765991.gif)

