### PR TITLE
Fixup docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.4.4] - 2018-05-05
+
+### Changed
+
+- more documentation fixup
+
 ## [0.4.3] - 2018-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ supports the `Convergence` methods  as well as interaction specific
 ones.
 
 ``` javascript
-import { Interactor } from '@bigtest/interaction';
+import { Interactor } from '@bigtest/interactor';
 
 let logIn = new Interactor('#login-form')   // optional scope selector
   .fill('.email-input', 'email@domain.tld') // fills in an email

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/interactions/count.js
+++ b/src/interactions/count.js
@@ -14,7 +14,7 @@ import { computed } from './helpers';
  * ```
  *
  * ``` javascript
- * @interactor class ListInteractor {
+ * \@interactor class ListInteractor {
  *   size = count('li')
  * }
  * ```

--- a/src/interactions/count.js
+++ b/src/interactions/count.js
@@ -14,7 +14,7 @@ import { computed } from './helpers';
  * ```
  *
  * ``` javascript
- * @interaction class ListInteractor {
+ * @interactor class ListInteractor {
  *   size = count('li')
  * }
  * ```

--- a/src/interactions/is-visible.js
+++ b/src/interactions/is-visible.js
@@ -59,6 +59,7 @@ export function isVisible() {
  * SVG elements that do not render anything themselves, `display:
  * none` elements, and generally any elements that are not rendered.
  *
+ * @function isVisible
  * @param {String} selector - Element query selector
  * @returns {Object} Property descriptor
  */

--- a/src/interactions/scrollable.js
+++ b/src/interactions/scrollable.js
@@ -7,8 +7,8 @@ import { action } from './helpers';
  * finally triggers a scroll event on the element.
  *
  * ``` javascript
- * await new Interaction('#page').scroll({ top: 100 })
- * await new Interaction('#page').scroll('.nested-view', { left: 100 })
+ * await new Interactor('#page').scroll({ top: 100 })
+ * await new Interactor('#page').scroll('.nested-view', { left: 100 })
  * ```
  *
  * @method Interactor#scroll

--- a/src/interactions/triggerable.js
+++ b/src/interactions/triggerable.js
@@ -6,6 +6,7 @@ import { action } from './helpers';
  * argument. This function normalizes the shorter form to match the
  * argument positions of the longer form.
  *
+ * @private
  * @param {Array} args - Arguments for `#trigger()`
  * @returns {Array} Normalized arguments
  */

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -21,7 +21,7 @@ import { isPresent } from './interactions/is-present';
  * ```
  *
  * In biology, an _interactor_ is defined as part of an organism that
- * natural selection acts upon. A `@bigtest/interaction` interactor
+ * natural selection acts upon. A `@bigtest/interactor` interactor
  * defines part of an _app_ that _tests_ act upon.
  *
  * ``` javascript


### PR DESCRIPTION
Looks like we missed a couple things in #19.

- Escaped the decorator in the count interaction. We missed this because it was `@interaction`.
- That prompted me to do a search and replace for other references to `interaction`. Hopefully I found the rest.
- There was a `module.exports` name in the docs which turned out to be the `isVisible` property creator missing a tag.
- I also noticed that the triggerable helper was being documented, so I marked it as private.