### PR TITLE
Fix example on PageInteractor

### DIFF
--- a/src/interactions/find.js
+++ b/src/interactions/find.js
@@ -28,7 +28,7 @@ export function find(selector) {
  * ```
  *
  * ``` javascript
- * let $heading = await new Interactor().getHeading()
+ * let $heading = await new PageInteractor().getHeading()
  * ```
  *
  * @function find


### PR DESCRIPTION
I believe this example should be calling creating a new `PageInteractor` instead of `Interactor`. 

I might be wrong, I was just taking a look in the docs and it stood out to me.