### PR TITLE
Relax property name restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- relax restrictions around reserved interactor properties
+
 ## [0.4.4] - 2018-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - relax restrictions around reserved interactor properties
+- default properties can be freely overwritten
 
 ## [0.4.4] - 2018-05-05
 

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,5 +1,24 @@
+import Convergence from '@bigtest/convergence';
 import Interactor from './interactor';
 import { isInteractor, isPropertyDescriptor } from './utils';
+
+/**
+ * Throws an error if an object contains reserved properties. Reserved
+ * properties are convergence prototype properties.
+ *
+ * @private
+ * @param {Object} obj - Object to check for reserved properties
+ * @throws {Error} if any reserverd properties were found
+ */
+function checkForReservedProperties(obj) {
+  let blacklist = Object.getOwnPropertyNames(Convergence.prototype);
+
+  for (let key of Object.keys(obj)) {
+    if (blacklist.includes(key)) {
+      throw new Error(`"${key}" is a reserved property name`);
+    }
+  }
+}
 
 /**
  * ``` javascript
@@ -67,16 +86,9 @@ export default function interactor(Class) {
     }
   }
 
-  // remove the given class's constructor
+  // remove the constructor and check for reserved properties
   delete proto.constructor;
-
-  // ensure that interactor methods and properties are not overwritten
-  // to avoid potential issues such as infinite recursion
-  for (let key of Object.keys(proto)) {
-    if (key in Interactor.prototype) {
-      throw new Error(`cannot redefine existing property "${key}"`);
-    }
-  }
+  checkForReservedProperties(proto);
 
   // extend the custom interactor's prototype
   Object.defineProperties(CustomInteractor.prototype, proto);

--- a/src/interactions/blurrable.js
+++ b/src/interactions/blurrable.js
@@ -1,5 +1,6 @@
 /* global Event */
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then triggers a
@@ -22,7 +23,7 @@ import { action } from './helpers';
  * @returns {Interactor} A new instance with additional convergences
  */
 export function blur(selector) {
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => {
       $node.dispatchEvent(
         new Event('blur', {
@@ -60,6 +61,6 @@ export function blur(selector) {
  */
 export default function(selector) {
   return action(function() {
-    return this.blur(selector);
+    return blur.call(this, selector);
   });
 }

--- a/src/interactions/clickable.js
+++ b/src/interactions/clickable.js
@@ -1,4 +1,5 @@
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then triggers a
@@ -23,7 +24,7 @@ import { action } from './helpers';
  * @returns {Interactor} A new instance with additional convergences
  */
 export function click(selector) {
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => $node.click());
 }
 
@@ -56,6 +57,6 @@ export function click(selector) {
  */
 export default function(selector) {
   return action(function() {
-    return this.click(selector);
+    return click.call(this, selector);
   });
 }

--- a/src/interactions/fillable.js
+++ b/src/interactions/fillable.js
@@ -1,5 +1,6 @@
 /* global Event */
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then sets its
@@ -34,7 +35,7 @@ export function fill(selectorOrValue, value) {
     selector = selectorOrValue;
   }
 
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => {
       // React has a custom property descriptor for the `value`
       // property of input elements. To work around this, we cache any
@@ -98,6 +99,6 @@ export function fill(selectorOrValue, value) {
  */
 export default function(selector) {
   return action(function(value) {
-    return this.fill(selector, value);
+    return fill.call(this, selector, value);
   });
 }

--- a/src/interactions/focusable.js
+++ b/src/interactions/focusable.js
@@ -1,5 +1,6 @@
 /* global Event */
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then triggers a
@@ -22,7 +23,7 @@ import { action } from './helpers';
  * @returns {Interactor} A new instance with additional convergences
  */
 export function focus(selector) {
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => {
       $node.dispatchEvent(
         new Event('focus', {
@@ -60,6 +61,6 @@ export function focus(selector) {
  */
 export default function(selector) {
   return action(function() {
-    return this.focus(selector);
+    return focus.call(this, selector);
   });
 }

--- a/src/interactions/scrollable.js
+++ b/src/interactions/scrollable.js
@@ -1,5 +1,6 @@
 /* global Event */
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then sets the
@@ -28,7 +29,7 @@ export function scroll(selectorOrScrollTo, scrollTo) {
     selector = selectorOrScrollTo;
   }
 
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => {
       if (typeof scrollTo.left === 'number') {
         $node.scrollLeft = scrollTo.left;
@@ -67,6 +68,6 @@ export function scroll(selectorOrScrollTo, scrollTo) {
  */
 export default function(selector) {
   return action(function(scrollTo) {
-    return this.scroll(selector, scrollTo);
+    return scroll.call(this, selector, scrollTo);
   });
 }

--- a/src/interactions/triggerable.js
+++ b/src/interactions/triggerable.js
@@ -1,5 +1,6 @@
 /* global Event */
 import { action } from './helpers';
+import { find } from './find';
 
 /**
  * Trigger has two forms, both of which have an optional last
@@ -54,7 +55,7 @@ function getTriggerArgs(args) {
 export function trigger(...args) {
   let [selector, eventName, options = {}] = getTriggerArgs(args);
 
-  return this.find(selector)
+  return find.call(this, selector)
     .do(($node) => {
       // default options for any event
       let bubbles = 'bubbles' in options ? options.bubbles : true;
@@ -102,6 +103,6 @@ export default function(...args) {
 
   return action(function(opts) {
     opts = Object.assign({}, options, opts);
-    return this.trigger(selector, eventName, opts);
+    return trigger.call(this, selector, eventName, opts);
   });
 }

--- a/tests/decorator-test.js
+++ b/tests/decorator-test.js
@@ -54,8 +54,20 @@ describe('BigTest Interaction: decorator', () => {
     expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
   });
 
-  it('throws an error when attempting to redefine existing properties', () => {
-    expect(() => interactor(class { get find() {} }))
-      .to.throw('cannot redefine existing property "find"');
+  it('throws an error when attempting to redefine reserved properties', () => {
+    let reserved = [
+      'when',
+      'always',
+      'do',
+      'timeout',
+      'run',
+      'then',
+      'append'
+    ];
+
+    for (let name of reserved) {
+      expect(() => interactor(class { [name]() {} }))
+        .to.throw(`"${name}" is a reserved property name`);
+    }
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,4 @@
-/* global beforeEach, afterEach */
+/* global beforeEach */
 
 /**
  * Inserts a fixture's HTML into a testing DOM element
@@ -7,17 +7,18 @@
  */
 export function useFixture(name) {
   let html = require(`html-loader!./fixtures/${name}.html`);
-  let $container;
 
   beforeEach(() => {
+    let $container = document.getElementById('test');
+
+    if ($container) {
+      document.body.removeChild($container);
+    }
+
     $container = document.createElement('div');
     $container.innerHTML = html;
     $container.id = 'test';
 
     document.body.insertBefore($container, document.body.firstChild);
-  });
-
-  afterEach(() => {
-    document.body.removeChild($container);
   });
 }

--- a/tests/interactions/blurrable-test.js
+++ b/tests/interactions/blurrable-test.js
@@ -41,4 +41,17 @@ describe('BigTest Interaction: blurrable', () => {
     await expect(test.blurInput().run()).to.be.fulfilled;
     expect(blurred).to.be.true;
   });
+
+  describe('overwriting the default blur method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.blur = blurrable('.test-input');
+      }))();
+    });
+
+    it('blurs the correct element', async () => {
+      await expect(test.blur().run()).to.be.fulfilled;
+      expect(blurred).to.be.true;
+    });
+  });
 });

--- a/tests/interactions/clickable-test.js
+++ b/tests/interactions/clickable-test.js
@@ -41,4 +41,17 @@ describe('BigTest Interaction: clickable', () => {
     await expect(test.clickBtn().run()).to.be.fulfilled;
     expect(clicked).to.be.true;
   });
+
+  describe('overwriting the default click method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.click = clickable('.test-btn');
+      }))();
+    });
+
+    it('clicks the correct element', async () => {
+      await expect(test.click().run()).to.be.fulfilled;
+      expect(clicked).to.be.true;
+    });
+  });
 });

--- a/tests/interactions/fillable-test.js
+++ b/tests/interactions/fillable-test.js
@@ -49,4 +49,17 @@ describe('BigTest Interaction: fillable', () => {
     await expect(test.fillInput('').run()).to.be.fulfilled;
     expect(events).to.have.members(['input', 'change']);
   });
+
+  describe('overwriting the default fill method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.fill = fillable('.test-input');
+      }))();
+    });
+
+    it('fills the correct element', async () => {
+      await expect(test.fill('something').run()).to.be.fulfilled;
+      expect($input.value).to.equal('something');
+    });
+  });
 });

--- a/tests/interactions/focusable-test.js
+++ b/tests/interactions/focusable-test.js
@@ -41,4 +41,17 @@ describe('BigTest Interaction: focusable', () => {
     await expect(test.focusInput().run()).to.be.fulfilled;
     expect(focused).to.be.true;
   });
+
+  describe('overwriting the default focus method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.focus = focusable('.test-input');
+      }))();
+    });
+
+    it('focuses the correct element', async () => {
+      await expect(test.focus().run()).to.be.fulfilled;
+      expect(focused).to.be.true;
+    });
+  });
 });

--- a/tests/interactions/scrollable-test.js
+++ b/tests/interactions/scrollable-test.js
@@ -43,4 +43,17 @@ describe('BigTest Interaction: scrollable', () => {
     await expect(test.scrollDiv({ top: 50, left: 100 }).run()).to.be.fulfilled;
     expect(offset).to.deep.equal({ top: 50, left: 100 });
   });
+
+  describe('overwriting the default scroll method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.scroll = scrollable('.test-div');
+      }))();
+    });
+
+    it('scrolls the correct element', async () => {
+      await expect(test.scroll({ left: 10 }).run()).to.be.fulfilled;
+      expect(offset).to.deep.equal({ top: 0, left: 10 });
+    });
+  });
 });

--- a/tests/interactions/triggerable-test.js
+++ b/tests/interactions/triggerable-test.js
@@ -66,4 +66,17 @@ describe('BigTest Interaction: triggerable', () => {
     expect(divEvent).to.have.property('custom', true);
     expect(divEvent).to.have.property('something', 'else');
   });
+
+  describe('overwriting the default trigger method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.trigger = triggerable('.test-div', 'divEvent');
+      }))();
+    });
+
+    it('triggers the event on the correct element', async () => {
+      await expect(test.trigger({ test: 0 }).run()).to.be.fulfilled;
+      expect(divEvent).to.have.property('test', 0);
+    });
+  });
 });


### PR DESCRIPTION
## Purpose 

While writing up some examples for a `FieldInteractor`, I found that with some interactors it makes sense to be able to override the default properties and methods.

For example:

``` js
@interactor class FieldInteractor {
  fill = fillable('input')
}
```

Before, this would throw an error about redefining `fill`. Since `fillable` uses `fill` under the hood, it would cause an infinite recursion error.

This also indirectly addresses #24 since the error message has changed, and it is about _reserved_ property names as opposed to "redefining properties."

## Approach

To avoid the recursion problem, the various `*able` property creators could make use of the proposed [bind operator](https://github.com/tc39/proposal-bind-operator): `this::find(...)`, but since it's just a proposal, using `find.call(this, ...)` works just as well.

The only reserved properties that will cause an error are convergence methods such as `when`, `always`, etc. But any default interactor properties and methods can now be freely redefined without any ill effects.

The error message thrown references the "reserved property name" as oppose to "redefined existing property." Hopefully this will be [less confusing](#24).

While adding tests, I missed a `.call` which caused some failures, so I went ahead and moved the test teardown so that they are easier to debug. Moving the teardown to the `beforeEach` hook allows us to inspect a test after it passes _or_ fails.