### PR TITLE
Add `scoped` property creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- `scoped` property creator for scoped interactors
+
 ### Changed
 
 - relax restrictions around reserved interactor properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - relax restrictions around reserved interactor properties
 - default properties can be freely overwritten
+- interactor decorator to support pojos
 
 ## [0.4.4] - 2018-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - `scoped` property creator for scoped interactors
+- `only` method so nested interactors can break out of parent chains
 
 ### Changed
 

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -48,7 +48,9 @@ function getInteractorDescriptors(instance) {
  * @throws {Error} if any reserverd properties were found
  */
 function checkForReservedProperties(obj) {
-  let blacklist = Object.getOwnPropertyNames(Convergence.prototype);
+  let blacklist = ['only'].concat(
+    Object.getOwnPropertyNames(Convergence.prototype)
+  );
 
   for (let key of Object.keys(obj)) {
     if (blacklist.includes(key)) {

--- a/src/interactions/collection.js
+++ b/src/interactions/collection.js
@@ -1,4 +1,3 @@
-import Interactor from '../interactor';
 import interactor from '../decorator';
 
 /**
@@ -89,18 +88,7 @@ import interactor from '../decorator';
  * @returns {Object} Property descriptor
  */
 export default function(selector, descriptors = {}) {
-  let ItemInteractor;
-
-  // if an interactor was provided, use it
-  if (descriptors.prototype instanceof Interactor) {
-    ItemInteractor = descriptors;
-
-    // otherwise, create a new one
-  } else {
-    ItemInteractor = interactor(function() {
-      Object.assign(this, descriptors);
-    });
-  }
+  let ItemInteractor = interactor(descriptors);
 
   return function(index) {
     // when no index is provided, map all elements to interactors

--- a/src/interactions/collection.js
+++ b/src/interactions/collection.js
@@ -28,6 +28,18 @@ import interactor from '../decorator';
  *   .item(1).click()
  * ```
  *
+ * Nested interactors also have an additional method, `#only()`, which
+ * disables the default nested chaining behavior, but retains any
+ * previous interactions.
+ *
+ * ``` javascript
+ * await checkboxGroup
+ *   .item(0).click()
+ *   .item(1).only()
+ *     .focus()
+ *     .trigger('keydown', { which: 32 })
+ * ```
+ *
  * When calling a collection method without an index, an array of
  * interactors are returned, each corresponding to an element in the
  * DOM at the time the method was invoked.

--- a/src/interactions/index.js
+++ b/src/interactions/index.js
@@ -6,6 +6,7 @@ export { default as blurrable } from './blurrable';
 export { default as triggerable } from './triggerable';
 export { default as scrollable } from './scrollable';
 export { default as collection } from './collection';
+export { default as scoped } from './scoped';
 
 // property creators
 export { default as find } from './find';

--- a/src/interactions/scoped.js
+++ b/src/interactions/scoped.js
@@ -31,6 +31,18 @@ import { computed } from './helpers';
  *   .submit()
  * ```
  *
+ * Nested interactors also have an additional method, `#only()`, which
+ * disables the default nested chaining behavior, but retains any
+ * previous interactions.
+ *
+ * ``` javascript
+ * await loginForm
+ *   .username.fill('h4x0r')
+ *   .email.only()
+ *     .fill('not@an@email')
+ *     .blur()
+ * ```
+ *
  * With the second argument, you can define additional interactions
  * using the various interaction helpers.
  *

--- a/src/interactions/scoped.js
+++ b/src/interactions/scoped.js
@@ -1,0 +1,93 @@
+import interactor from '../decorator';
+import { computed } from './helpers';
+
+/**
+ * Interaction creator for a single nested interactor.
+ *
+ * ``` html
+ * <form class="login-form">
+ *   <input type="text" name="username" />
+ *   <input type="email" name="email" />
+ *   <button type="submit">Login</button>
+ * </form>
+ * ```
+
+ * ``` javascript
+ * \@interactor class LoginFormInteractor {
+ *   username = scoped('input[name="username"]')
+ *   email = scoped('input[name="email"]')
+ *   submit = clickable('button[type="submit"]')
+ * }
+ * ```
+ *
+ * Nested interactions return instances of the topmost interactor so
+ * that the initial chain is never broken.
+ *
+ * ``` javascript
+ * await loginForm
+ *   .username.fill('darklord1926')
+ *   .email.fill('tom.riddle@hogwarts.edu')
+ *   .email.blur()
+ *   .submit()
+ * ```
+ *
+ * With the second argument, you can define additional interactions
+ * using the various interaction helpers.
+ *
+ * ``` html
+ * <label class="field username-field">
+ *   <span class="field-label">Username:</span>
+ *   <input type="text" name="username" />
+ * </label>
+ * ```
+ *
+ * ``` javascript
+ * \@interactor class FormInteractor {
+ *   username = scoped('.username-field', {
+ *     label: text('.field-label'),
+ *     fillIn: fillable('input')
+ *   })
+ * }
+ * ```
+ *
+ * You can also use another interactor class.
+ *
+ * ``` javascript
+ * \@interactor class FieldInteractor {
+ *   label = text('.field-label')
+ *
+ *   fillIn(value) {
+ *     return this.scoped('input')
+ *      .focus().fill(value).blur()
+ *   }
+ * }
+ *
+ * \@interactor class LoginFormInteractor {
+ *   username = scoped('.username-field', FieldInteractor)
+ *   email = scoped('.email-field', FieldInteractor)
+ *   submit = clickable('button[type="submit"]')
+ * }
+ * ```
+ *
+ * ``` javascript
+ * await loginForm
+ *   .username.fillIn('darklord1926')
+ *   .email.fillIn('tom.riddle@hogwarts.edu')
+ *   .submit()
+ * ```
+ *
+ * @function scoped
+ * @param {String} selector - Element query selector
+ * @param {Object} [descriptors] - Interaction descriptors
+ * @returns {Object} Property descriptor
+ */
+export default function(selector, descriptors = {}) {
+  let ScopedInteractor = interactor(descriptors);
+
+  return computed(function() {
+    return new ScopedInteractor({
+      parent: this,
+      scope: () => this.$(selector)
+    });
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,3 +119,26 @@ export function getMethodNames(instance) {
       typeof descr[name].value === 'function';
   });
 }
+
+/**
+ * Returns a wrapped function that will maybe return a parent instance
+ * from chainable methods with any resulting instance appended to it.
+ *
+ * Chainable methods are methods which return new instances of their
+ * own interactor.
+ *
+ * @private
+ * @param {Interactor} instance - Interactor instance to wrap
+ * @param {String} method - Method name to wrap
+ * @returns {Function} Wrapped method
+ */
+export function maybeNested(instance, method) {
+  return (...args) => {
+    let result = instance[method].apply(instance, args);
+
+    // same instance results are chained instances
+    return result instanceof instance.constructor
+      ? instance.parent.append(result)
+      : result;
+  };
+}

--- a/tests/decorator-test.js
+++ b/tests/decorator-test.js
@@ -66,7 +66,8 @@ describe('BigTest Interaction: decorator', () => {
       'timeout',
       'run',
       'then',
-      'append'
+      'append',
+      'only'
     ];
 
     for (let name of reserved) {

--- a/tests/decorator-test.js
+++ b/tests/decorator-test.js
@@ -54,6 +54,10 @@ describe('BigTest Interaction: decorator', () => {
     expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
   });
 
+  it('nested interactor methods return parent instances', () => {
+    expect(new TestInteractor().nested.do(() => {})).to.be.an.instanceOf(TestInteractor);
+  });
+
   it('throws an error when attempting to redefine reserved properties', () => {
     let reserved = [
       'when',
@@ -69,5 +73,33 @@ describe('BigTest Interaction: decorator', () => {
       expect(() => interactor(class { [name]() {} }))
         .to.throw(`"${name}" is a reserved property name`);
     }
+  });
+
+  describe('with a plain object', () => {
+    beforeEach(() => {
+      TestInteractor = interactor({
+        foo: 'bar',
+
+        test: {
+          enumerable: false,
+          configurable: false,
+          value: () => 'test'
+        },
+
+        get getter() {
+          return 'got';
+        },
+
+        nested: new Interactor()
+      });
+    });
+
+    it('returns an interactor class with the specified properties', () => {
+      expect(new TestInteractor()).to.have.property('foo', 'bar');
+      expect(new TestInteractor()).to.have.property('getter', 'got');
+      expect(new TestInteractor()).to.respondTo('test');
+      expect(new TestInteractor().nested).to.be.an.instanceOf(Interactor);
+      expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
+    });
   });
 });

--- a/tests/fixtures/field-fixture.html
+++ b/tests/fixtures/field-fixture.html
@@ -1,0 +1,4 @@
+<label class="test-field">
+  <span class="test-label">Test</span>
+  <input type="text"/>
+</label>

--- a/tests/interactions/collection-test.js
+++ b/tests/interactions/collection-test.js
@@ -29,9 +29,10 @@ describe('BigTest Interaction: collection', () => {
 
   it('returns an interactor scoped to the element at an index', () => {
     expect(test.simple(2))
-      .to.be.an('object')
-      .that.has.property('$root')
+      .to.have.property('$root')
       .that.has.property('id', 'c');
+    expect(test.items(2)).to.have.property('parent', test);
+    expect(test.items(2)).to.respondTo('only');
   });
 
   it('returns an array of interactors when no index is provided', () => {
@@ -69,9 +70,14 @@ describe('BigTest Interaction: collection', () => {
     expect(clickedB).to.be.true;
   });
 
-  it('returns a new parent instance from collection interactor methods', () => {
+  it('returns new parent instances from collection methods', () => {
     expect(test.items(0).click()).to.not.equal(test);
     expect(test.items(0).click()).to.be.an.instanceOf(CollectionInteractor);
+  });
+
+  it('returns own instances from collection methods after calling #only', () => {
+    expect(test.items(0).only()).to.be.an.instanceOf(ItemInteractor);
+    expect(test.items(0).only().click()).to.be.an.instanceOf(ItemInteractor);
   });
 
   it('lazily throws an error when the element does not exist', () => {

--- a/tests/interactions/collection-test.js
+++ b/tests/interactions/collection-test.js
@@ -11,10 +11,6 @@ const ItemInteractor = interactor(function() {
 const CollectionInteractor = interactor(function() {
   this.simple = collection('.test-item');
   this.items = collection('.test-item', ItemInteractor);
-  this.nested = collection('.test-item', {
-    content: text('.test-p'),
-    clickBtn: clickable('button')
-  });
 });
 
 describe('BigTest Interaction: collection', () => {
@@ -29,7 +25,6 @@ describe('BigTest Interaction: collection', () => {
   it('has collection methods', () => {
     expect(test).to.respondTo('simple');
     expect(test).to.respondTo('items');
-    expect(test).to.respondTo('nested');
   });
 
   it('returns an interactor scoped to the element at an index', () => {
@@ -46,8 +41,9 @@ describe('BigTest Interaction: collection', () => {
   });
 
   it('has nested interactions', () => {
-    expect(test.nested(1)).to.have.property('content');
-    expect(test.nested(1)).to.respondTo('clickBtn');
+    expect(test.items(1)).to.be.an.instanceOf(ItemInteractor);
+    expect(test.items(1)).to.have.property('content');
+    expect(test.items(1)).to.respondTo('clickBtn');
   });
 
   it('has a scoped text property', () => {

--- a/tests/interactions/scoped-test.js
+++ b/tests/interactions/scoped-test.js
@@ -31,6 +31,7 @@ describe('BigTest Interaction: scoped', () => {
     expect(test.simple).to.have.property('$root')
       .that.has.property('className', 'test-field');
     expect(test.field).to.be.an.instanceOf(FieldInteractor);
+    expect(test.field).to.respondTo('only');
   });
 
   it('has nested interactions', async () => {
@@ -50,6 +51,11 @@ describe('BigTest Interaction: scoped', () => {
   it('returns parent instances from nested interaction methods', () => {
     expect(test.field.click()).to.not.equal(test);
     expect(test.field.click()).to.be.an.instanceOf(ScopedInteractor);
+  });
+
+  it('returns own instances after calling #only()', () => {
+    expect(test.field.only()).to.be.an.instanceOf(FieldInteractor);
+    expect(test.field.only().click()).to.be.an.instanceOf(FieldInteractor);
   });
 
   it('lazily throws an error when the element does not exist', () => {

--- a/tests/interactions/scoped-test.js
+++ b/tests/interactions/scoped-test.js
@@ -1,0 +1,61 @@
+/* global describe, beforeEach, it */
+import { expect } from 'chai';
+import { useFixture } from '../helpers';
+import { interactor, scoped, text, fillable } from '../../src';
+
+const FieldInteractor = interactor(function() {
+  this.label = text('.test-label');
+  this.fillIn = fillable('input');
+});
+
+const ScopedInteractor = interactor(function() {
+  this.simple = scoped('.test-field');
+  this.field = scoped('.test-field', FieldInteractor);
+});
+
+describe('BigTest Interaction: scoped', () => {
+  let test;
+
+  useFixture('field-fixture');
+
+  beforeEach(() => {
+    test = new ScopedInteractor();
+  });
+
+  it('has scoped properties', () => {
+    expect(test).to.have.property('simple');
+    expect(test).to.have.property('field');
+  });
+
+  it('returns a nested interactor', () => {
+    expect(test.simple).to.have.property('$root')
+      .that.has.property('className', 'test-field');
+    expect(test.field).to.be.an.instanceOf(FieldInteractor);
+  });
+
+  it('has nested interactions', async () => {
+    let value;
+
+    expect(test.field).to.be.an.instanceOf(FieldInteractor);
+    expect(test.field).to.have.property('label', 'Test');
+
+    test.field.$('input')
+      .addEventListener('change', e => value = e.target.value);
+
+    await test.field.fillIn('hello');
+
+    expect(value).to.equal('hello');
+  });
+
+  it('returns parent instances from nested interaction methods', () => {
+    expect(test.field.click()).to.not.equal(test);
+    expect(test.field.click()).to.be.an.instanceOf(ScopedInteractor);
+  });
+
+  it('lazily throws an error when the element does not exist', () => {
+    let field = new ScopedInteractor('#non-existent').field;
+
+    return expect(() => field.$root)
+      .to.throw('unable to find "#non-existent"');
+  });
+});


### PR DESCRIPTION
## Purpose

Like `collection`, the `scoped` property creator will return an interactor for a specific scoped element. This scoped, nested interactor can have additional properties defined, or even use a specific interactor.

``` js
@interactor class FormInteractor {
  name = scoped('.name-field', {
    fill: fillable('input')
  });

  // ... or
  email = scoped('.email-field', FieldInteractor);
}
```

``` js
await new FormInteractor()
  .name.fill('My Name')
  .email.fill('email@address.tld')
```

This actually addresses #1, although that specific issue suggests creating a few helpers for specific element types. I don't think the specific helpers like `input` would be necessary since #2 will address validating whether something is actually focusable with `focus()`, for example.

In addition to the `scoped` property creator, this PR also adds an `.only()` method for nested interactors. This method allows nested interactors, such as the above, to break out of the parent chain relationship.

``` js
await new FormInteractor()
  .email.only()
    .focus()
    .fill('email@address.tld')
    .blur()
```

## Approach

Depends on #26, because `only` needs to be a reserved property to prevent nested interactors from accidentally defining their own `only` method.

Since the second argument logic was needed to be repeated from the `collection` helper, I opted to create a util function for it. However, it was much cleaner to just allow the decorator to accept a POJO as well as a class. To align it with what `collection` did, given an existing interactor, the decorator will simply return it and do nothing.

In the future, this decorator could be aliased to a static `extend` allowing one to extend existing interactors with additional properties.

``` js
@interactor class FormInteractor {
  // would have the same methods and properties as other fields
  password = scoped('.password-field', FieldInteractor.extend({
    // with an additional property specific to this password field
    isVisible: computed(function() {
      return this.$('input').type !== 'password'
    })
  });
}
```

Since the decorator grew by a few lines, I thought it was the right time to extract out the descriptor logic into it's own function.

And since the interactor constructor also grew by a few lines, I made the nested method wrapper into it's own util function.