### PR TITLE
Add select method and selectable creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - `scoped` property creator for scoped interactors
 - `only` method so nested interactors can break out of parent chains
+- `select` method and `selectable` property creator
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The interaction getters return the state of the scoped element.
 
 - `.click(selector)`
 - `.fill(selector, value)`
+- `.select(selector, option)`
 - `.focus(selector)`
 - `.blur(selector)`
 - `.trigger(selector, event, eventOptions)`
@@ -225,6 +226,7 @@ freely, with the exception of Convergence methods `when`, `always`,
 - `blurrable(selector)`
 - `triggerable(selector, event, eventOptions)`
 - `fillable(selector) => function(value)`
+- `selectable(selector) => function(option)`
 - `scrollable(selector) => function({ left, top })`
 
 Just like interactor methods, you may omit any `selector` to interact

--- a/src/interactions/index.js
+++ b/src/interactions/index.js
@@ -1,6 +1,7 @@
 // interaction creators
 export { default as clickable } from './clickable';
 export { default as fillable } from './fillable';
+export { default as selectable } from './selectable';
 export { default as focusable } from './focusable';
 export { default as blurrable } from './blurrable';
 export { default as triggerable } from './triggerable';

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -1,0 +1,102 @@
+/* global Event */
+import { action } from './helpers';
+import { find } from './find';
+
+/**
+ * Converges on an element first existing in the DOM, then selects a
+ * matching option based on the text content, and triggers a `change`
+ * events for the select element.
+ *
+ * ``` html
+ * <form ...>
+ *   <select id="month">
+ *     <option value="1">January</option>
+ *     <option value="2">February</option>
+ *     <option value="3">March</option>
+ *     ...
+ *   </select>
+ *   ...
+ * </form>
+ * ```
+ *
+ * ``` javascript
+ * await new Interactor('select').select('February')
+ * await new Interactor('form').fill('select#month', 'March')
+ * ```
+ *
+ * @method Interactor#select
+ * @param {String} [selector] - Nested element query selector
+ * @param {String} option - Option text to select
+ * @returns {Interactor} A new instance with additional convergences
+ */
+export function select(selectorOrOption, option) {
+  let selector;
+
+  // if option is not defined, it is assumed that the only passed
+  // argument is the option for the root element
+  if (typeof option === 'undefined') {
+    option = selectorOrOption;
+  } else {
+    selector = selectorOrOption;
+  }
+
+  return find.call(this, selector)
+    .when(($select) => {
+      // find the option by text content
+      for (let $option of $select.options) {
+        if ($option.text === option) {
+          return [$select, $option];
+        }
+      }
+
+      throw new Error(`unable to find option "${option}"`);
+    })
+    .do(([$select, $option]) => {
+      // select the option
+      $option.selected = true;
+
+      // dispatch change event
+      $select.dispatchEvent(
+        new Event('change', {
+          bubbles: true,
+          cancelable: true
+        })
+      );
+    });
+}
+
+/**
+ * Interaction creator for selecting an option of a specific select
+ * element within a custom interactor class.
+ *
+ * ``` html
+ * <form ...>
+ *   <select id="month">
+ *     <option value="1">January</option>
+ *     <option value="2">February</option>
+ *     <option value="3">March</option>
+ *     ...
+ *   </select>
+ *   ...
+ * </form>
+ * ```
+ *
+ * ``` javascript
+ * \@interactor class FormInteractor {
+ *   selectMonth = selectable('select#month')
+ * }
+ * ```
+ *
+ * ``` javascript
+ * await new FormInteractor('form').selectMonth('February')
+ * ```
+ *
+ * @function selectable
+ * @param {String} selector - Element query selector
+ * @returns {Object} Property descriptor
+ */
+export default function(selector) {
+  return action(function(option) {
+    return select.call(this, selector, option);
+  });
+}

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -4,8 +4,8 @@ import { find } from './find';
 
 /**
  * Converges on an element first existing in the DOM, then selects a
- * matching option based on the text content, and triggers a `change`
- * events for the select element.
+ * matching option based on the text content, and triggers `change`
+ * and `input` events for the select element.
  *
  * ``` html
  * <form ...>
@@ -54,6 +54,14 @@ export function select(selectorOrOption, option) {
     .do(([$select, $option]) => {
       // select the option
       $option.selected = true;
+
+      // dispatch input event
+      $select.dispatchEvent(
+        new Event('input', {
+          bubbles: true,
+          cancelable: true
+        })
+      );
 
       // dispatch change event
       $select.dispatchEvent(

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -6,6 +6,7 @@ import { find } from './interactions/find';
 import { findAll } from './interactions/find-all';
 import { click } from './interactions/clickable';
 import { fill } from './interactions/fillable';
+import { select } from './interactions/selectable';
 import { focus } from './interactions/focusable';
 import { blur } from './interactions/blurrable';
 import { trigger } from './interactions/triggerable';
@@ -260,6 +261,7 @@ Object.defineProperties(
     findAll,
     click,
     fill,
+    select,
     focus,
     blur,
     trigger,

--- a/tests/fixtures/select-fixture.html
+++ b/tests/fixtures/select-fixture.html
@@ -1,0 +1,5 @@
+<select class="test-select">
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+  <option value="3">Option 3</option>
+</select>

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -8,14 +8,15 @@ const SelectInteractor = interactor(function() {
 });
 
 describe('BigTest Interaction: selectable', () => {
-  let test, $select, changed;
+  let test, $select, events;
 
   useFixture('select-fixture');
 
   beforeEach(() => {
-    changed = false;
+    events = [];
     $select = document.querySelector('.test-select');
-    $select.addEventListener('change', () => changed = true);
+    $select.addEventListener('input', () => events.push('input'));
+    $select.addEventListener('change', () => events.push('change'));
     test = new SelectInteractor();
   });
 
@@ -42,11 +43,11 @@ describe('BigTest Interaction: selectable', () => {
 
   it('eventually fires a change event', async () => {
     await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
-    expect(changed).to.be.true;
+    expect(events).to.have.members(['input', 'change']);
 
-    changed = false;
+    events = [];
     await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
-    expect(changed).to.be.true;
+    expect(events).to.have.members(['input', 'change']);
   });
 
   it('throws an error when the option cannot be found', async () => {

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -1,0 +1,69 @@
+/* global describe, beforeEach, it */
+import { expect } from 'chai';
+import { useFixture } from '../helpers';
+import { interactor, selectable } from '../../src';
+
+const SelectInteractor = interactor(function() {
+  this.selectOption = selectable('.test-select');
+});
+
+describe('BigTest Interaction: selectable', () => {
+  let test, $select, changed;
+
+  useFixture('select-fixture');
+
+  beforeEach(() => {
+    changed = false;
+    $select = document.querySelector('.test-select');
+    $select.addEventListener('change', () => changed = true);
+    test = new SelectInteractor();
+  });
+
+  it('has selectable methods', () => {
+    expect(test).to.respondTo('select');
+    expect(test).to.respondTo('selectOption');
+  });
+
+  it('returns a new instance', () => {
+    expect(test.select('.test-select')).to.not.equal(test);
+    expect(test.select('.test-select')).to.be.an.instanceOf(SelectInteractor);
+    expect(test.selectOption('Option 1')).to.not.equal(test);
+    expect(test.selectOption('Option 1')).to.be.an.instanceOf(SelectInteractor);
+  });
+
+  it('eventually selects the option', async () => {
+    await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
+    expect($select.value).to.equal('1');
+
+    $select.value = '';
+    await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
+    expect($select.value).to.equal('2');
+  });
+
+  it('eventually fires a change event', async () => {
+    await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
+    expect(changed).to.be.true;
+
+    changed = false;
+    await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
+    expect(changed).to.be.true;
+  });
+
+  it('throws an error when the option cannot be found', async () => {
+    await expect(test.selectOption('nothing').timeout(50).run())
+      .to.be.rejectedWith('unable to find option "nothing"');
+  });
+
+  describe('overwriting the default select method', () => {
+    beforeEach(() => {
+      test = new (interactor(function() {
+        this.select = selectable('.test-select');
+      }))();
+    });
+
+    it('selects the correct option', async () => {
+      await expect(test.select('Option 3').run()).to.be.fulfilled;
+      expect($select.value).to.equal('3');
+    });
+  });
+});


### PR DESCRIPTION
## Purpose

Currently, we can use fill/fillable to set the value of a `<select>` element. However, in practice we typically select an option based on it's text value

## Approach

The select method fails when it cannot find the option with the specified text. This is done within a `.when` so that options which are dynamically added have a chance to render into the DOM. Once the option is found, is has it's `selected` property set to `true` and `input` & `change` events are triggered on the select element.