### PR TITLE
Update convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-05-26
+
 ### Added
 
 - `scoped` property creator for scoped interactors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - relax restrictions around reserved interactor properties
 - default properties can be freely overwritten
 - interactor decorator to support pojos
+- upgrade `@bigtest/convergence` to `0.9.1`
 
 ## [0.4.4] - 2018-05-05
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,12 +20,12 @@ module.exports = (config) => {
       module: {
         rules: [{
           test: /\.js$/,
-          exclude: /node_modules(?!\/@bigtest)/,
+          exclude: /node_modules/,
           loader: 'babel-loader',
           options: {
             babelrc: false,
             presets: [
-              ['@babel/preset-env', {
+              ['@babel/env', {
                 modules: false
               }]
             ]

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.7.0"
+    "@bigtest/convergence": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,9 +517,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@bigtest/convergence@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.7.0.tgz#df577d7e78b453cf80b4f29acf66dd7f60fcc0c1"
+"@bigtest/convergence@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.9.1.tgz#ddbe3e85e757b8fb82b80df95ed2e574c9d24429"
 
 "@bigtest/meta@bigtestjs/meta#v0.0.1":
   version "0.0.1"


### PR DESCRIPTION
## Purpose

There have been a few releases of `@bigtest/convergence` since it was last updated for this package.

Since the newer versions of `@bigtest/convergence` have proper ES modules, we no longer need to build it with webpack in our `karma.config.js` file.

## Approach

- Update `@bigtest/convergence` to `v0.9.1`
- Remove the regex negation in the karma webpack config
- Release a new version of this package

### TODOs

- [x] If we wait until the other few PRs get merged, we can also release those along with this.