### PR TITLE
Fix deeply nested interactor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- a bug where interactors returned from deeply nested methods were not
+  instances of the topmost parent
+
 ## [0.5.0] - 2018-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.5.1] - 2018-07-02
+
 ### Fixed
 
 - a bug where interactors returned from deeply nested methods were not

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,14 +97,14 @@ export function isPropertyDescriptor(descr) {
 }
 
 /**
- * Returns an array of all method names found on an object including
- * any inherited methods (not including Object.prototype).
+ * Returns all descriptors found on an object including any inherited
+ * descriptors (not including the constructor or Object descriptors).
  *
  * @private
  * @param {Object} instance - Instance to find methods for
- * @returns {String[]} Array of method names
+ * @returns {Object} own and inherited descriptors
  */
-export function getMethodNames(instance) {
+export function getDescriptors(instance) {
   let proto = Object.getPrototypeOf(instance);
   let descr = {};
 
@@ -114,31 +114,7 @@ export function getMethodNames(instance) {
     proto = Object.getPrototypeOf(proto);
   }
 
-  return Object.keys(descr).filter(name => {
-    return name !== 'constructor' &&
-      typeof descr[name].value === 'function';
-  });
-}
-
-/**
- * Returns a wrapped function that will maybe return a parent instance
- * from chainable methods with any resulting instance appended to it.
- *
- * Chainable methods are methods which return new instances of their
- * own interactor.
- *
- * @private
- * @param {Interactor} instance - Interactor instance to wrap
- * @param {String} method - Method name to wrap
- * @returns {Function} Wrapped method
- */
-export function maybeNested(instance, method) {
-  return (...args) => {
-    let result = instance[method].apply(instance, args);
-
-    // same instance results are chained instances
-    return result instanceof instance.constructor
-      ? instance.parent.append(result)
-      : result;
-  };
+  // do not return the constructor
+  delete descr.constructor;
+  return descr;
 }

--- a/tests/decorator-test.js
+++ b/tests/decorator-test.js
@@ -51,7 +51,8 @@ describe('BigTest Interaction: decorator', () => {
   it('attaches a parent to nested interactors', () => {
     expect(new TestInteractor().nested).to.be.an.instanceOf(Interactor);
     expect(new TestInteractor().nested).to.not.be.an.instanceOf(TestInteractor);
-    expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
+    expect(new TestInteractor().nested)
+      .to.have.property('__parent__').that.is.an.instanceOf(TestInteractor);
   });
 
   it('nested interactor methods return parent instances', () => {
@@ -99,8 +100,8 @@ describe('BigTest Interaction: decorator', () => {
       expect(new TestInteractor()).to.have.property('foo', 'bar');
       expect(new TestInteractor()).to.have.property('getter', 'got');
       expect(new TestInteractor()).to.respondTo('test');
-      expect(new TestInteractor().nested).to.be.an.instanceOf(Interactor);
-      expect(new TestInteractor().nested.parent).to.be.an.instanceOf(TestInteractor);
+      expect(new TestInteractor().nested).to.be.an.instanceOf(Interactor)
+        .that.has.property('__parent__').that.is.an.instanceOf(TestInteractor);
     });
   });
 });

--- a/tests/interactions/collection-test.js
+++ b/tests/interactions/collection-test.js
@@ -28,17 +28,12 @@ describe('BigTest Interaction: collection', () => {
   });
 
   it('returns an interactor scoped to the element at an index', () => {
-    expect(test.simple(2))
-      .to.have.property('$root')
-      .that.has.property('id', 'c');
-    expect(test.items(2)).to.have.property('parent', test);
+    expect(test.simple(2)).to.have.property('$root').that.has.property('id', 'c');
     expect(test.items(2)).to.respondTo('only');
   });
 
   it('returns an array of interactors when no index is provided', () => {
-    expect(test.simple())
-      .to.be.an('Array')
-      .that.has.lengthOf(4);
+    expect(test.simple()).to.be.an('Array').that.has.lengthOf(4);
   });
 
   it('has nested interactions', () => {
@@ -48,10 +43,7 @@ describe('BigTest Interaction: collection', () => {
   });
 
   it('has a scoped text property', () => {
-    expect(test.items(3))
-      .to.have.property('content')
-      .that.is.a('string')
-      .that.equals('Item D');
+    expect(test.items(3)).to.have.property('content').that.equals('Item D');
   });
 
   it('has scoped clickable properties', async () => {


### PR DESCRIPTION
## Purpose

I discovered an issue where deeply nested interactor methods did not properly return the topmost interactor instance.

**Expected**
``` js
parent.child.items(0).click() //=> instanceof parent
```

**Actual**
``` js
parent.child.items(0).click() //=> instanceof child
```

This happens because methods of nested interactors are always bound to a non-wrapped instance so that chaining inside of methods do not return parent instances.

In this example, the interactor bound to `items` is the non-wrapped `child` that _does not_ return it's own parent. Therefore all nested methods of `items` only return instances of `child`.

## Approach

Refactor the parent chain mechanism so that all nested instances always contain references to any parent.

While refactoring, I noticed that getters referenced the wrapped nested instance which could cause them to return an instance of a parent instead of itself. So I made sure that getters are bound to the non-wrapped instance just as methods are.

The `parent` property was also renamed to `__parent__` because I realized that if a custom interactor defined `parent`, it would either not work, or cause nesting to not work.

The parent tests were refactored along with the parent chaining mechanism. This is so the tests accurately depict how nested interactors are created. Other tests referencing the `parent` property were also adjusted.