### PR TITLE
Nested interactor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - `scoped` interactor method to return nested and scoped interactors
+- ability to specify a selector function for collections
 
 ## [0.5.1] - 2018-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- `scoped` interactor method to return nested and scoped interactors
+
 ## [0.5.1] - 2018-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.6.0] - 2018-07-03
+
 ### Added
 
 - `scoped` interactor method to return nested and scoped interactors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -4,6 +4,7 @@ import { $, $$, isInteractor, getDescriptors } from './utils';
 import { action, computed } from './interactions/helpers';
 import { find } from './interactions/find';
 import { findAll } from './interactions/find-all';
+import { scoped } from './interactions/scoped';
 import { click } from './interactions/clickable';
 import { fill } from './interactions/fillable';
 import { select } from './interactions/selectable';
@@ -281,6 +282,7 @@ Object.defineProperties(
   Object.entries({
     find,
     findAll,
+    scoped,
     click,
     fill,
     select,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+/* global Element */
 import { isConvergence } from '@bigtest/convergence';
 
 /**
@@ -10,7 +11,7 @@ import { isConvergence } from '@bigtest/convergence';
  * @returns {Element} Matching element
  */
 export function $(selector, $ctx = document) {
-  let $node = selector;
+  let $node = null;
 
   if (!$ctx || typeof $ctx.querySelector !== 'function') {
     throw new Error('unable to use the current context');
@@ -19,7 +20,11 @@ export function $(selector, $ctx = document) {
   if (typeof selector === 'string') {
     $node = $ctx.querySelector(selector);
 
-  // if a non-string is falsy, return the context element
+  // if an element was given, return it
+  } else if (selector instanceof Element) {
+    return selector;
+
+  // if the selector is falsy, return the context element
   } else if (!selector) {
     return $ctx;
   }
@@ -47,11 +52,17 @@ export function $$(selector, $ctx = document) {
     throw new Error('unable to use the current context');
   }
 
+  // given a string, use `querySelectorAll`
   if (typeof selector === 'string') {
     nodes = [].slice.call($ctx.querySelectorAll(selector));
+
+  // given an iterable, assume it contains nodes
+  } else if (Symbol.iterator in Object(selector)) {
+    nodes = [].slice.call(selector);
   }
 
-  return nodes;
+  // only return elements
+  return nodes.filter(($node) => $node instanceof Element);
 }
 
 /**

--- a/tests/interactions/collection-test.js
+++ b/tests/interactions/collection-test.js
@@ -11,6 +11,11 @@ const ItemInteractor = interactor(function() {
 const CollectionInteractor = interactor(function() {
   this.simple = collection('.test-item');
   this.items = collection('.test-item', ItemInteractor);
+
+  this.byId = collection(
+    (id) => id ? `#${id}` : '.test-item',
+    ItemInteractor
+  );
 });
 
 describe('BigTest Interaction: collection', () => {
@@ -25,15 +30,26 @@ describe('BigTest Interaction: collection', () => {
   it('has collection methods', () => {
     expect(test).to.respondTo('simple');
     expect(test).to.respondTo('items');
+    expect(test).to.respondTo('byId');
   });
 
   it('returns an interactor scoped to the element at an index', () => {
-    expect(test.simple(2)).to.have.property('$root').that.has.property('id', 'c');
-    expect(test.items(2)).to.respondTo('only');
+    expect(test.simple(0)).to.have.property('$root').that.has.property('id', 'a');
+    expect(test.items(1)).to.have.property('$root').that.has.property('id', 'b');
   });
 
-  it('returns an array of interactors when no index is provided', () => {
+  it('returns an interactor scoped to the element by a generated selector', () => {
+    expect(test.byId('c')).to.have.property('$root').that.has.property('id', 'c');
+  });
+
+  it('returns an array of interactors when no argument is provided', () => {
     expect(test.simple()).to.be.an('Array').that.has.lengthOf(4);
+    expect(test.items()).to.be.an('Array').that.has.lengthOf(4);
+    expect(test.byId()).to.be.an('Array').that.has.lengthOf(4)
+      .that.satisfies((items) => items.every((item) => {
+        return expect(item).to.be.an.instanceof(ItemInteractor)
+          .and.have.property('$root').that.has.property('className', 'test-item');
+      }));
   });
 
   it('has nested interactions', () => {
@@ -43,7 +59,7 @@ describe('BigTest Interaction: collection', () => {
   });
 
   it('has a scoped text property', () => {
-    expect(test.items(3)).to.have.property('content').that.equals('Item D');
+    expect(test.byId('d')).to.have.property('content').that.equals('Item D');
   });
 
   it('has scoped clickable properties', async () => {
@@ -55,10 +71,10 @@ describe('BigTest Interaction: collection', () => {
     document.querySelector('#b')
       .addEventListener('click', () => clickedB = true);
 
-    await expect(test.items(0).clickBtn().run()).to.be.fulfilled;
+    await expect(test.byId('a').clickBtn().run()).to.be.fulfilled;
     expect(clickedA).to.be.true;
 
-    await expect(test.items(1).click().run()).to.be.fulfilled;
+    await expect(test.byId('b').click().run()).to.be.fulfilled;
     expect(clickedB).to.be.true;
   });
 

--- a/tests/interactions/scoped-test.js
+++ b/tests/interactions/scoped-test.js
@@ -27,11 +27,16 @@ describe('BigTest Interaction: scoped', () => {
     expect(test).to.have.property('field');
   });
 
+  it('has a scoped method', () => {
+    expect(test).to.respondTo('scoped');
+  });
+
   it('returns a nested interactor', () => {
     expect(test.simple).to.have.property('$root')
       .that.has.property('className', 'test-field');
-    expect(test.field).to.be.an.instanceOf(FieldInteractor);
-    expect(test.field).to.respondTo('only');
+    expect(test.field).to.be.an.instanceOf(FieldInteractor).and.respondTo('only');
+    expect(test.scoped('.test-field', FieldInteractor))
+      .to.be.an.instanceOf(FieldInteractor).and.respondTo('only');
   });
 
   it('has nested interactions', async () => {
@@ -51,6 +56,7 @@ describe('BigTest Interaction: scoped', () => {
   it('returns parent instances from nested interaction methods', () => {
     expect(test.field.click()).to.not.equal(test);
     expect(test.field.click()).to.be.an.instanceOf(ScopedInteractor);
+    expect(test.scoped('.test-field').click()).to.be.an.instanceOf(ScopedInteractor);
   });
 
   it('returns own instances after calling #only()', () => {


### PR DESCRIPTION
## Purpose

Frequently, while writing tests using the `collection` helper, it is not clear which item in the collection you are working with based solely on the index.

For example:

``` js
expect(form.token.options(5).isDisabled).to.be.true;
```

It would be more helpful to be able to select an item within a collection based on some other argument.

``` js
expect(form.token.options('top-hat').isDisabled).to.be.true;
```

## Approach

Initially, the `scoped` method was added, which returns a scoped and nested interactor. This works just like the `scoped` property creator, but can be used programmatically within custom methods.

``` js
options(value) {
  return this.scoped(`[value="${value}"]`, {
    isDisabled: property('disabled')
  });
}
```

This alone is enough to make the above expectation possible. But if you want to return a list when no argument is provided, you would have to map the results of `this.$$(selector)` to new, un-nested, interactor instances.

By allowing the `collection` helper to accept a function as the selector, the selector can be generated from passed arguments. However, it must still return a selector that matches multiple elements when no argument is provided.

``` js
options = collection(
  (value) => value ? `[value="${value}"]` : '[type="radio"]',
  { isDisabled: property('disabled') }
);
```

Providing both of these options allows for easy-to-define custom collection methods.