### PR TITLE
Fix interactor parent bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - better error for invalid query selector strings
 
+### Fixed
+
+- a bug where parent interactors were returned within nested
+  methods when using deeper nested methods
+
 ## [0.7.0] - 2018-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.7.1] - 2018-07-20
+
 ### Added
 
 - better error for invalid query selector strings

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,3 +137,19 @@ export function getDescriptors(instance) {
   delete descr.constructor;
   return descr;
 }
+
+/**
+ * Returns an instance of the topmost parent interactor by appending
+ * the interactor up the chain of its parents.
+ *
+ * @private
+ * @param {Interactor} interactor - Potentially nested interactor
+ * @returns {Interactor} topmost interactor instance
+ */
+export function appendUp(interactor) {
+  while (interactor.__parent__) {
+    interactor = interactor.__parent__.append(interactor);
+  }
+
+  return interactor;
+}

--- a/tests/interactor-test.js
+++ b/tests/interactor-test.js
@@ -107,6 +107,8 @@ describe('BigTest Interaction: Interactor', () => {
       deep() {
         return new DeepInteractor({ parent: this });
       }
+
+      test4() { return this.deep().test().deep().test(); }
     }
 
     class DeepInteractor extends Interactor {
@@ -126,6 +128,7 @@ describe('BigTest Interaction: Interactor', () => {
       expect(parent.child.test1()).to.be.an.instanceof(ParentInteractor);
       expect(parent.child.test2()).to.be.an.instanceof(ParentInteractor);
       expect(parent.child.deep().test()).to.be.an.instanceof(ParentInteractor);
+      expect(parent.child.test4()).to.be.an.instanceof(ParentInteractor);
     });
 
     it('appends child interactions to the parent instance queue', () => {


### PR DESCRIPTION
## Purpose

This bug was introduced in `0.5.1` which fixed a bug where deeply nested interactors returned their immediate parent instead of the topmost parent. This new bug happens within nested interactor methods, when using further nested interactions results in the topmost parent being returned, when the current interactor should have been returned instead.

This took me a bit to wrap my head around, so I made some diagrams to help:

![diagrams](https://user-images.githubusercontent.com/5005153/43016791-94e2ba3e-8c19-11e8-8264-724ca141a5c0.png)

## Approach

Instead of binding the unwrapped instance of nested interactors for methods and getters, an orphaned version of the unwrapped instance is bound instead. After the method or getter is executed, either the parent is reunited, or the instance is appended up the parent chain as before.

`appendUp` didn't need to be defined within the interactor constructor, so it was moved to utils.