### PR TITLE
Make invalid selector error better across browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- better error for invalid query selector strings
+
 ## [0.7.0] - 2018-07-06
 
 ### Changed

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,11 @@ export function $(selector, $ctx = document) {
   }
 
   if (typeof selector === 'string') {
-    $node = $ctx.querySelector(selector);
+    try {
+      $node = $ctx.querySelector(selector);
+    } catch (e) {
+      throw new SyntaxError(`"${selector}" is not a valid selector`);
+    }
 
   // if an element was given, return it
   } else if (selector instanceof Element) {
@@ -54,7 +58,11 @@ export function $$(selector, $ctx = document) {
 
   // given a string, use `querySelectorAll`
   if (typeof selector === 'string') {
-    nodes = [].slice.call($ctx.querySelectorAll(selector));
+    try {
+      nodes = [].slice.call($ctx.querySelectorAll(selector));
+    } catch (e) {
+      throw new SyntaxError(`"${selector}" is not a valid selector`);
+    }
 
   // given an iterable, assume it contains nodes
   } else if (Symbol.iterator in Object(selector)) {

--- a/tests/interactor-test.js
+++ b/tests/interactor-test.js
@@ -52,6 +52,15 @@ describe('BigTest Interaction: Interactor', () => {
       expect(() => scoped.$root).to.throw('unable to find "#not-scoped"');
     });
 
+    it('throws when the selector is invalid', () => {
+      let scoped = new Interactor('.#not-valid').timeout(50);
+
+      expect(() => scoped.$root).to.throw(
+        SyntaxError,
+        '".#not-valid" is not a valid selector'
+      );
+    });
+
     it('can have an evaulated scope', () => {
       let scopeID;
       let scoped = new Interactor(() => `#${scopeID}`);


### PR DESCRIPTION
## Purpose

The syntax error produced by the `querySelector` and `querySelectorAll` functions are not consistent across browsers.

- In Webkit, the error thrown is `SyntaxError: The string did not match the expected pattern.`
- In Blink, the error thrown is `Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '${selector}' is not a valid selector.`
- In Gecko, the error thrown is `SyntaxError:  '${selector}' is not a valid selector.`

## Approach

It does not appear as though these function throw any other error besides a syntax error (except in Chrome it throws `DOMException`). So we can wrap `querySelector` in a try-catch block and throw a better error.

The Webkit error is the least helpful, and the Blink error is quite verbose (and not even a syntax error), so I opted to error exactly what Gecko does.