### PR TITLE
Fix nested scoping issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- a bug where deeply nested interactors lost their scoped root element
+
 ## [0.7.1] - 2018-07-20
 
 ### Added
@@ -13,8 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- a bug where parent interactors were returned within nested
-  methods when using deeper nested methods
+- a bug where parent interactors were returned within nested methods
+  when using deeper nested methods
 
 ## [0.7.0] - 2018-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.7.2] - 2018-07-23
+
 ### Fixed
 
 - a bug where deeply nested interactors lost their scoped root element

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -1,6 +1,13 @@
 /* global Element */
 import Convergence from '@bigtest/convergence';
-import { $, $$, isInteractor, getDescriptors, appendUp } from './utils';
+import {
+  $,
+  $$,
+  isInteractor,
+  getDescriptor,
+  getDescriptors,
+  appendUp
+} from './utils';
 import { action, computed } from './interactions/helpers';
 import { find } from './interactions/find';
 import { findAll } from './interactions/find-all';
@@ -137,7 +144,7 @@ class Interactor extends Convergence {
       __parent__: { value: parent },
 
       // the previous descriptor always takes precedence
-      $root: Object.getOwnPropertyDescriptor(previous, '$root') || {
+      $root: getDescriptor(previous, '$root') || {
         get: () => $(typeof scope === 'function' ? scope() : scope)
       }
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,11 +116,33 @@ export function isPropertyDescriptor(descr) {
 }
 
 /**
- * Returns all descriptors found on an object including any inherited
- * descriptors (not including the constructor or Object descriptors).
+ * Returns a descriptor found on an object including inherited
+ * descriptors (not including Object descriptors).
  *
  * @private
- * @param {Object} instance - Instance to find methods for
+ * @param {Object} instance - Instance to find a descriptor for
+ * @param {String} key - Property key
+ * @returns {Object} found descriptor, or null
+ */
+export function getDescriptor(instance, key) {
+  let proto = instance;
+  let descr = null;
+
+  while (proto && proto !== Object.prototype) {
+    descr = Object.getOwnPropertyDescriptor(proto, key);
+    proto = Object.getPrototypeOf(proto);
+    if (descr) break;
+  }
+
+  return descr;
+}
+
+/**
+ * Returns all descriptors found on an object's prototype chain not
+ * including own properties, the constructor, or Object descriptors.
+ *
+ * @private
+ * @param {Object} instance - Instance to find descriptors for
  * @returns {Object} own and inherited descriptors
  */
 export function getDescriptors(instance) {
@@ -128,7 +150,7 @@ export function getDescriptors(instance) {
   let descr = {};
 
   while (proto && proto !== Object.prototype) {
-    // uses descriptors to avoid invoking getters when filtering
+    // prioritize property descriptors closest to the instance prototype
     descr = Object.assign({}, Object.getOwnPropertyDescriptors(proto), descr);
     proto = Object.getPrototypeOf(proto);
   }

--- a/tests/interactor-test.js
+++ b/tests/interactor-test.js
@@ -47,6 +47,11 @@ describe('BigTest Interaction: Interactor', () => {
       expect(scoped.$root).to.equal($scope);
     });
 
+    it('retains the correct nested scopes', () => {
+      let scoped = new Interactor().scoped('#scoped').scoped('.test-p');
+      expect(scoped).to.have.property('text', 'Scoped');
+    });
+
     it('throws when scope does not exist', () => {
       let scoped = new Interactor('#not-scoped').timeout(50);
       expect(() => scoped.$root).to.throw('unable to find "#not-scoped"');


### PR DESCRIPTION
## Purpose

In `0.7.1`, a bug was introduced where deeply nested interactors lost reference to their scoped `$root` element. This caused issues where interactions were acting on the wrong part of the DOM.

The issue was introduced with the additions [here](https://github.com/bigtestjs/interactor/blob/f79d9b028350310f7b6fba4f77e7260fc4689672/src/interactor.js#L169-L171), but interactors were always vulnerable. We used `Object.getOwnPropertyDescriptor` to carry the scope `$root` forward in the immutable structure, but the instance created with `Object.create` **does not** have it's own `$root` property.

## Approach

We can either duplicate the `$root` as an _own_ property of the `Object.create` instance, or look up the prototype chain to find the `$root` property. Out of the two options, it _sounds_ like looking up the chain is the safer, future-proof option.
