### PR TITLE
Fix minor typo in examples

### DIFF
--- a/src/interactor.js
+++ b/src/interactor.js
@@ -68,7 +68,7 @@ import { isPresent } from './interactions/is-present';
  * ``` javascript
  * new Interactor('#some-form')
  *   .fill('input[type="email"]', 'email@domain.tld')
- *   .click('buttom[type="submit"]')
+ *   .click('button[type="submit"]')
  * ```
  *
  * You can create custom interactors by extending the class...
@@ -81,7 +81,7 @@ import { isPresent } from './interactions/is-present';
  *   }
  *
  *   submit() {
- *     return this.click('buttom[type="submit"]')
+ *     return this.click('button[type="submit"]')
  *   }
  *
  *   fillAndSubmit(email) {


### PR DESCRIPTION
I noticed a minor typo in the examples for `@bigtest/interactor` under the `new interactor (scope)` section where `button` is spelled `buttom`. This change fixes that typo. 

#### Screenshot of original typo
<img width="918" alt="screen shot 2018-07-26 at 9 35 38 am" src="https://user-images.githubusercontent.com/25858667/43272478-a7c5216e-90bf-11e8-993a-02319f93eb8b.png">
