### PR TITLE
Update fillable.js so that the value is set on the dispatched event.

### DIFF
--- a/src/interactions/fillable.js
+++ b/src/interactions/fillable.js
@@ -53,7 +53,8 @@ export function fill(selectorOrValue, value) {
       $node.dispatchEvent(
         new Event('input', {
           bubbles: true,
-          cancelable: true
+          cancelable: true,
+          value
         })
       );
 
@@ -61,7 +62,8 @@ export function fill(selectorOrValue, value) {
       $node.dispatchEvent(
         new Event('change', {
           bubbles: true,
-          cancelable: true
+          cancelable: true,
+          value
         })
       );
 


### PR DESCRIPTION
A common pattern in redux-bound fields, is to pull the value from the event, rather than the element itself. 
This change includes the value on the dispatched event so that common react/redux patterns will be able to pull the value from `onChange={e => this.setState({ value: e.target.value })}`