### PR TITLE
Add CHANGELOG probot config

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -1,0 +1,3 @@
+filename: CHANGELOG.md
+include:
+  - /^src\//

--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,2 +1,0 @@
-# Close the source issue after moving
-closeSourceIssue: true


### PR DESCRIPTION
## What is this?

[This probot](https://github.com/mikz/probot-changelog) will check to see if any files were changed in the `src` directory (that's configurable) without an update to the `CHANGELOG` file. If so it will let you know on your PR.

This is so no PRs can be merged without updating the CHANGELOG.

If this works out for this repo I'd like to apply it to all BigTest repos
