### PR TITLE
Call an elements `blur` method for interactors `blurrable` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - call the elements `focus` method inside of `focusable` to set focus
+- call the elements `blur` method inside of `blurrable` to unset focus
 
 ## [0.7.2] - 2018-07-23
 

--- a/src/interactions/blurrable.js
+++ b/src/interactions/blurrable.js
@@ -1,4 +1,3 @@
-/* global Event */
 import { action } from './helpers';
 import { find } from './find';
 
@@ -23,15 +22,9 @@ import { find } from './find';
  * @returns {Interactor} A new instance with additional convergences
  */
 export function blur(selector) {
-  return find.call(this, selector)
-    .do(($node) => {
-      $node.dispatchEvent(
-        new Event('blur', {
-          bubbles: true,
-          cancelable: true
-        })
-      );
-    });
+  return find.call(this, selector).do($node => {
+    $node.blur();
+  });
 }
 
 /**

--- a/tests/interactions/blurrable-test.js
+++ b/tests/interactions/blurrable-test.js
@@ -8,16 +8,21 @@ const BlurInteractor = interactor(function() {
 });
 
 describe('BigTest Interaction: blurrable', () => {
-  let blurred, test;
+  let blurred, test, $input;
 
   useFixture('input-fixture');
 
   beforeEach(() => {
     blurred = false;
+    $input = document.querySelector('.test-input');
 
-    document.querySelector('.test-input')
-      .addEventListener('blur', () => blurred = true);
+    $input.addEventListener('blur', e => {
+      blurred = e.target !== document.activeElement;
+    });
 
+    // Set focus on the element so we can check if blur has properly
+    // been handled
+    $input.focus();
     test = new BlurInteractor();
   });
 
@@ -36,8 +41,9 @@ describe('BigTest Interaction: blurrable', () => {
   it('eventually blurs the element', async () => {
     await expect(test.blur('.test-input').run()).to.be.fulfilled;
     expect(blurred).to.be.true;
+  });
 
-    blurred = false;
+  it('eventually blurs the custom element', async () => {
     await expect(test.blurInput().run()).to.be.fulfilled;
     expect(blurred).to.be.true;
   });

--- a/tests/interactions/blurrable-test.js
+++ b/tests/interactions/blurrable-test.js
@@ -2,22 +2,28 @@
 import { expect } from 'chai';
 import { useFixture } from '../helpers';
 import { interactor, blurrable } from '../../src';
+import { when } from '@bigtest/convergence';
 
 const BlurInteractor = interactor(function() {
   this.blurInput = blurrable('.test-input');
 });
 
 describe('BigTest Interaction: blurrable', () => {
-  let blurred, test, $input;
+  let blurred, focusOut, test, $input;
 
   useFixture('input-fixture');
 
   beforeEach(() => {
     blurred = false;
+    focusOut = false;
     $input = document.querySelector('.test-input');
 
     $input.addEventListener('blur', e => {
       blurred = e.target !== document.activeElement;
+    });
+
+    $input.addEventListener('focusout', e => {
+      focusOut = e.target !== document.activeElement;
     });
 
     // Set focus on the element so we can check if blur has properly
@@ -40,12 +46,18 @@ describe('BigTest Interaction: blurrable', () => {
 
   it('eventually blurs the element', async () => {
     await expect(test.blur('.test-input').run()).to.be.fulfilled;
-    expect(blurred).to.be.true;
+    await when(() => {
+      expect(blurred).to.be.true;
+      expect(focusOut).to.be.true;
+    });
   });
 
   it('eventually blurs the custom element', async () => {
     await expect(test.blurInput().run()).to.be.fulfilled;
-    expect(blurred).to.be.true;
+    await when(() => {
+      expect(blurred).to.be.true;
+      expect(focusOut).to.be.true;
+    });
   });
 
   describe('overwriting the default blur method', () => {


### PR DESCRIPTION
## What is this?

Much like the work that happened in #44, we want to call the DOM nodes `blur` method instead of sending the `blur` event directly. This will blur that specific event and send two events (`blur` & `focusout`). 