### PR TITLE
Allow `select` and `selectable` to select options on multiple `select`s

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 110
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - call the elements `focus` method inside of `focusable` to set focus
 - call the elements `blur` method inside of `blurrable` to unset focus
 
+### Added
+
+- selecting multiple options from multiselect with `select` & `selectable`
+
 ## [0.7.2] - 2018-07-23
 
 ### Fixed

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -24,18 +24,45 @@ import { find } from './find';
  * await new Interactor('form').fill('select#month', 'March')
  * ```
  *
+ * For multiple selects you can pass an array of options you would
+ * like to select.
+ *
+ * ``` html
+ * <form ...>
+ *   <select id="month" multiple>
+ *     <option value="1">January</option>
+ *     <option value="2">February</option>
+ *     <option value="3">March</option>
+ *     ...
+ *   </select>
+ *   ...
+ * </form>
+ * ```
+ *
+ * ``` javascript
+ * await new Interactor('select').select(['February', 'March'])
+ *
+ * // or with a custom interactor
+ * \@interactor class CustomInteractor {
+ *   selectOption = selectable();
+ * }
+ *
+ * let select = new CustomInteractor('#month');
+ * select.selectOption(['February', 'March']);
+ * ```
+ *
  * @method Interactor#select
  * @param {String} [selector] - Nested element query selector
- * @param {String} option - Option text to select
+ * @param {String|String[]} options - Option or array of options text to select
  * @returns {Interactor} A new instance with additional convergences
  */
-export function select(selectorOrOption, option) {
+export function select(selectorOrOption, options) {
   let selector;
 
   // if option is not defined, it is assumed that the only passed
   // argument is the option for the root element
-  if (typeof option === 'undefined') {
-    option = selectorOrOption;
+  if (typeof options === 'undefined') {
+    options = selectorOrOption;
   } else {
     selector = selectorOrOption;
   }
@@ -44,21 +71,33 @@ export function select(selectorOrOption, option) {
     .call(this, selector)
     .when($select => {
       // find the option by text content
-      for (let $option of $select.options) {
-        if ($option.text === option) {
-          return [$select, $option];
-        }
+      return [
+        $select,
+        [].concat(options).map(option => {
+          for (let $option of $select.options) {
+            if ($option.text === option) {
+              return $option;
+            }
+          }
+
+          throw new Error(`unable to find option "${option}"`);
+        })
+      ];
+    })
+    .do(([$select, $options]) => {
+      if (!$select.multiple && $options.length > 1) {
+        throw new Error(`unable to select more than one option for "${selector}"`);
       }
 
-      throw new Error(`unable to find option "${option}"`);
-    })
-    .do(([$select, $option]) => {
-      if ($select.multiple && $option.selected) {
-        // toggle the option to not be selected
-        $option.selected = false;
+      if ($select.multiple) {
+        $options.forEach(option => {
+          // since multiple selects can toggle selection, we'll toggle
+          // the option to the opposite of what it is now
+          option.selected = !option.selected;
+        });
       } else {
         // select the option
-        $option.selected = true;
+        $options[0].selected = true;
       }
 
       // dispatch input event

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -60,13 +60,20 @@ export function select(selectorOrOption, options) {
     selector = selectorOrOption;
   }
 
+  // turn options into an array
+  options = [].concat(options);
+
   return find
     .call(this, selector)
     .when($select => {
+      if (!$select.multiple && options.length > 1) {
+        throw new Error(`unable to select more than one option for "${selector}"`);
+      }
+
       // find the option by text content
       return [
         $select,
-        [].concat(options).map(option => {
+        options.map(option => {
           for (let $option of $select.options) {
             if ($option.text === option) {
               return $option;
@@ -78,10 +85,6 @@ export function select(selectorOrOption, options) {
       ];
     })
     .do(([$select, $options]) => {
-      if (!$select.multiple && $options.length > 1) {
-        throw new Error(`unable to select more than one option for "${selector}"`);
-      }
-
       if ($select.multiple) {
         $options.forEach(option => {
           // since multiple selects can toggle selection, we'll toggle

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -40,8 +40,9 @@ export function select(selectorOrOption, option) {
     selector = selectorOrOption;
   }
 
-  return find.call(this, selector)
-    .when(($select) => {
+  return find
+    .call(this, selector)
+    .when($select => {
       // find the option by text content
       for (let $option of $select.options) {
         if ($option.text === option) {
@@ -52,8 +53,13 @@ export function select(selectorOrOption, option) {
       throw new Error(`unable to find option "${option}"`);
     })
     .do(([$select, $option]) => {
-      // select the option
-      $option.selected = true;
+      if ($select.multiple && $option.selected) {
+        // toggle the option to not be selected
+        $option.selected = false;
+      } else {
+        // select the option
+        $option.selected = true;
+      }
 
       // dispatch input event
       $select.dispatchEvent(

--- a/src/interactions/selectable.js
+++ b/src/interactions/selectable.js
@@ -41,14 +41,7 @@ import { find } from './find';
  *
  * ``` javascript
  * await new Interactor('select').select(['February', 'March'])
- *
- * // or with a custom interactor
- * \@interactor class CustomInteractor {
- *   selectOption = selectable();
- * }
- *
- * let select = new CustomInteractor('#month');
- * select.selectOption(['February', 'March']);
+ * await new Interactor('form').select('select#month', ['February', 'March'])
  * ```
  *
  * @method Interactor#select
@@ -142,6 +135,31 @@ export function select(selectorOrOption, options) {
  *
  * ``` javascript
  * await new FormInteractor('form').selectMonth('February')
+ * ```
+ *
+ * For multiple selects you can pass an array of options you would
+ * like to select.
+ *
+ * ``` html
+ * <form ...>
+ *   <select id="month" multiple>
+ *     <option value="1">January</option>
+ *     <option value="2">February</option>
+ *     <option value="3">March</option>
+ *     ...
+ *   </select>
+ *   ...
+ * </form>
+ * ```
+ *
+ * ``` javascript
+ * \@interactor class FormInteractor {
+ *   selectMonth = selectable('select#month')
+ * }
+ * ```
+ *
+ * ``` javascript
+ * await new FormInteractor('form').selectMonth(['February', 'March']);
  * ```
  *
  * @function selectable

--- a/tests/fixtures/multiselect-fixture.html
+++ b/tests/fixtures/multiselect-fixture.html
@@ -1,0 +1,5 @@
+<select class="test-select" multiple>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+  <option value="3">Option 3</option>
+</select>

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -8,10 +8,6 @@ const SelectInteractor = interactor(function() {
   this.selectOption = selectable('.test-select');
 });
 
-const getSelectedOptions = $select => {
-  return [...$select.options].filter(option => option.selected).map(option => option.value);
-};
-
 describe('BigTest Interaction: selectable', () => {
   let test, $select, events;
 
@@ -65,6 +61,12 @@ describe('BigTest Interaction: selectable', () => {
       ).to.be.rejectedWith('unable to find option "nothing"');
     });
 
+    it('can not pass multiple options', async () => {
+      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.rejectedWith(
+        'unable to select more than one option for ".test-select"'
+      );
+    });
+
     describe('overwriting the default select method', () => {
       beforeEach(() => {
         test = new (interactor(function() {
@@ -88,12 +90,38 @@ describe('BigTest Interaction: selectable', () => {
     });
 
     it('can deselect currently selected options', async () => {
-      await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
-      await expect(test.select('.test-select', 'Option 2').run()).to.be.fulfilled;
-      expect(getSelectedOptions($select)).to.eql(['1', '2']);
+      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.fulfilled;
+      expect($select.selectedOptions.length).to.equal(2);
+      expect($select.selectedOptions[0].text).to.equal('Option 1');
+      expect($select.selectedOptions[1].text).to.equal('Option 2');
 
       await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
-      expect(getSelectedOptions($select)).to.eql(['1']);
+      expect($select.selectedOptions.length).to.equal(1);
+      expect($select.selectedOptions[0].text).to.equal('Option 1');
+    });
+
+    it('can deselect all options', async () => {
+      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.fulfilled;
+      expect($select.selectedOptions.length).to.equal(2);
+      expect($select.selectedOptions[0].text).to.equal('Option 1');
+      expect($select.selectedOptions[1].text).to.equal('Option 2');
+
+      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.fulfilled;
+      expect($select.selectedOptions.length).to.equal(0);
+    });
+
+    it('can pass multiple options to be selected', async () => {
+      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.fulfilled;
+      expect($select.selectedOptions.length).to.equal(2);
+      expect($select.selectedOptions[0].text).to.equal('Option 1');
+      expect($select.selectedOptions[1].text).to.equal('Option 2');
+    });
+
+    it('can pass multiple options to be selected on a custom element', async () => {
+      await expect(test.selectOption(['Option 1', 'Option 2']).run()).to.be.fulfilled;
+      expect($select.selectedOptions.length).to.equal(2);
+      expect($select.selectedOptions[0].text).to.equal('Option 1');
+      expect($select.selectedOptions[1].text).to.equal('Option 2');
     });
   });
 });

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -1,4 +1,5 @@
 /* global describe, beforeEach, it */
+
 import { expect } from 'chai';
 import { useFixture } from '../helpers';
 import { interactor, selectable } from '../../src';
@@ -7,64 +8,92 @@ const SelectInteractor = interactor(function() {
   this.selectOption = selectable('.test-select');
 });
 
+const getSelectedOptions = $select => {
+  return [...$select.options].filter(option => option.selected).map(option => option.value);
+};
+
 describe('BigTest Interaction: selectable', () => {
   let test, $select, events;
 
-  useFixture('select-fixture');
+  describe('with a single select', () => {
+    useFixture('select-fixture');
 
-  beforeEach(() => {
-    events = [];
-    $select = document.querySelector('.test-select');
-    $select.addEventListener('input', () => events.push('input'));
-    $select.addEventListener('change', () => events.push('change'));
-    test = new SelectInteractor();
-  });
-
-  it('has selectable methods', () => {
-    expect(test).to.respondTo('select');
-    expect(test).to.respondTo('selectOption');
-  });
-
-  it('returns a new instance', () => {
-    expect(test.select('.test-select')).to.not.equal(test);
-    expect(test.select('.test-select')).to.be.an.instanceOf(SelectInteractor);
-    expect(test.selectOption('Option 1')).to.not.equal(test);
-    expect(test.selectOption('Option 1')).to.be.an.instanceOf(SelectInteractor);
-  });
-
-  it('eventually selects the option', async () => {
-    await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
-    expect($select.value).to.equal('1');
-
-    $select.value = '';
-    await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
-    expect($select.value).to.equal('2');
-  });
-
-  it('eventually fires a change event', async () => {
-    await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
-    expect(events).to.have.members(['input', 'change']);
-
-    events = [];
-    await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
-    expect(events).to.have.members(['input', 'change']);
-  });
-
-  it('throws an error when the option cannot be found', async () => {
-    await expect(test.selectOption('nothing').timeout(50).run())
-      .to.be.rejectedWith('unable to find option "nothing"');
-  });
-
-  describe('overwriting the default select method', () => {
     beforeEach(() => {
-      test = new (interactor(function() {
-        this.select = selectable('.test-select');
-      }))();
+      events = [];
+      $select = document.querySelector('.test-select');
+      $select.addEventListener('input', () => events.push('input'));
+      $select.addEventListener('change', () => events.push('change'));
+      test = new SelectInteractor();
     });
 
-    it('selects the correct option', async () => {
-      await expect(test.select('Option 3').run()).to.be.fulfilled;
-      expect($select.value).to.equal('3');
+    it('has selectable methods', () => {
+      expect(test).to.respondTo('select');
+      expect(test).to.respondTo('selectOption');
+    });
+
+    it('returns a new instance', () => {
+      expect(test.select('.test-select')).to.not.equal(test);
+      expect(test.select('.test-select')).to.be.an.instanceOf(SelectInteractor);
+      expect(test.selectOption('Option 1')).to.not.equal(test);
+      expect(test.selectOption('Option 1')).to.be.an.instanceOf(SelectInteractor);
+    });
+
+    it('eventually selects the option', async () => {
+      await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
+      expect($select.value).to.equal('1');
+
+      $select.value = '';
+      await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
+      expect($select.value).to.equal('2');
+    });
+
+    it('eventually fires a change event', async () => {
+      await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
+      expect(events).to.have.members(['input', 'change']);
+
+      events = [];
+      await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
+      expect(events).to.have.members(['input', 'change']);
+    });
+
+    it('throws an error when the option cannot be found', async () => {
+      await expect(
+        test
+          .selectOption('nothing')
+          .timeout(50)
+          .run()
+      ).to.be.rejectedWith('unable to find option "nothing"');
+    });
+
+    describe('overwriting the default select method', () => {
+      beforeEach(() => {
+        test = new (interactor(function() {
+          this.select = selectable('.test-select');
+        }))();
+      });
+
+      it('selects the correct option', async () => {
+        await expect(test.select('Option 3').run()).to.be.fulfilled;
+        expect($select.value).to.equal('3');
+      });
+    });
+  });
+
+  describe('with a multiselect', () => {
+    useFixture('multiselect-fixture');
+
+    beforeEach(() => {
+      $select = document.querySelector('.test-select');
+      test = new SelectInteractor();
+    });
+
+    it('can deselect currently selected options', async () => {
+      await expect(test.select('.test-select', 'Option 1').run()).to.be.fulfilled;
+      await expect(test.select('.test-select', 'Option 2').run()).to.be.fulfilled;
+      expect(getSelectedOptions($select)).to.eql(['1', '2']);
+
+      await expect(test.selectOption('Option 2').run()).to.be.fulfilled;
+      expect(getSelectedOptions($select)).to.eql(['1']);
     });
   });
 });

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -1,5 +1,4 @@
 /* global describe, beforeEach, it */
-
 import { expect } from 'chai';
 import { useFixture } from '../helpers';
 import { interactor, selectable } from '../../src';
@@ -122,6 +121,15 @@ describe('BigTest Interaction: selectable', () => {
       expect($select.selectedOptions.length).to.equal(2);
       expect($select.selectedOptions[0].text).to.equal('Option 1');
       expect($select.selectedOptions[1].text).to.equal('Option 2');
+    });
+
+    it('throws an error when trying to select an option that does not exist', async () => {
+      await expect(
+        test
+          .timeout(50)
+          .selectOption(['Option 1', 'Race car'])
+          .run()
+      ).to.be.rejectedWith('unable to find option "Race car"');
     });
   });
 });

--- a/tests/interactions/selectable-test.js
+++ b/tests/interactions/selectable-test.js
@@ -61,9 +61,12 @@ describe('BigTest Interaction: selectable', () => {
     });
 
     it('can not pass multiple options', async () => {
-      await expect(test.select('.test-select', ['Option 1', 'Option 2']).run()).to.be.rejectedWith(
-        'unable to select more than one option for ".test-select"'
-      );
+      await expect(
+        test
+          .timeout(50)
+          .select('.test-select', ['Option 1', 'Option 2'])
+          .run()
+      ).to.be.rejectedWith('unable to select more than one option for ".test-select"');
     });
 
     describe('overwriting the default select method', () => {


### PR DESCRIPTION
## Problem

While creating the `x-select` interactor I ran into an issue where I couldn't select multiple options from `multiple` `<select>`s. 

Given this interactor:

```js
@interactor class xSelectInteractor {
  selectOption = selectable();
  options = collection("option", {
    isSelected: hasClass("is-selected")
  });
}
```

With this test:

```js
let xselect = new xSelectInteractor('.x-select');

it("sets focus", async () => {
  await xselect.selectOption(['first', 'second']);

  await when(() => { 
    expect(xselect.options(0).isSelected).to.equal(true)
    expect(xselect.options(1).isSelected).to.equal(true)
  });
});
```

I would expect to be able to select both options in a multiselect. 

## Approach 

This PR implements the API seen above exactly. You can now pass an array of options to `select` & `selectable`. If you try to select multiple options from a normal select, it will throw an error. You also cannot deselect options from a normal select. But you can deselect options from a multiple select by selecting the same option again.
