### PR TITLE
Collection documentation is missing an 's' in item

### DIFF
--- a/src/interactions/collection.js
+++ b/src/interactions/collection.js
@@ -25,8 +25,8 @@ import { action } from './helpers';
  *
  * ``` javascript
  * await checkboxGroup
- *   .item(0).click()
- *   .item(1).click()
+ *   .items(0).click()
+ *   .items(1).click()
  * ```
  *
  * Nested interactors also have an additional method, `#only()`, which
@@ -35,8 +35,8 @@ import { action } from './helpers';
  *
  * ``` javascript
  * await checkboxGroup
- *   .item(0).click()
- *   .item(1).only()
+ *   .items(0).click()
+ *   .items(1).only()
  *     .focus()
  *     .trigger('keydown', { which: 32 })
  * ```


### PR DESCRIPTION
There is a missing "s" in collection documentation

![missing](https://user-images.githubusercontent.com/501129/46704046-e6d25880-cbee-11e8-9146-351cf73f110a.png)

