### PR TITLE
Update convergence to fix date mocking issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- upgrade @bigtest/convergence to fix date mocking bug
+
 ## [0.9.0] - 2018-10-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.9.1] - 2018-10-23
+
 ### Changed
 
 - upgrade @bigtest/convergence to fix date mocking bug

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "webpack-dev-server": "^3.1.9"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.10.0"
+    "@bigtest/convergence": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,11 @@
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.10.0.tgz#ed2212b7034c84917ccfbaa8cf875730ee535702"
   integrity sha512-jJBPq3TTmMD/s/5k/mINzL6EXyPdNq0cEDZXufICFjpXmuUabRS/PX/NfzmXVlNENDJ6yOrDnrsO4IJboNTu9g==
 
+"@bigtest/convergence@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-1.1.1.tgz#b314d8b1edc392d3e8780f99499a9a03aa528d54"
+  integrity sha512-zorukvQJ7JxD5Jqy3ChzhCJzlD45bZudBASbgJvY5ffw5Hu+/9Ia/+8KlU1/XRWm32O2P5SBB2soHoFtGi1eGQ==
+
 "@bigtest/meta@bigtestjs/meta":
   version "0.0.1"
   resolved "https://codeload.github.com/bigtestjs/meta/tar.gz/45e15f4eacea3b83733f7585804f5658e91aa917"


### PR DESCRIPTION
## Purpose

bigtestjs/convergence#23 outlines an issue with convergences and date mocking. bigtestjs/convergence#24 fixes this issue and releases `1.1.1`.

## Approach

Pull in the latest `@bigtest/convergence` so interactors can work in an environment with mocked dates.