### PR TITLE
Ensure a valid target when this.only is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Make sure $root descriptor function is not wrapped in the chaining mechanism - https://github.com/bigtestjs/interactor/pull/60 
+
 ## [0.9.1] - 2018-10-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.9.2] - 2018-02-05
+
 ### Fixed
 
 - Make sure $root descriptor function is not wrapped in the chaining mechanism - https://github.com/bigtestjs/interactor/pull/60 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interactor",
   "description": "Interaction library for testing big",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/interactor",
   "main": "dist/umd/index.js",

--- a/src/utils/parent-chainable.js
+++ b/src/utils/parent-chainable.js
@@ -33,7 +33,8 @@ function isSameType(a, b) {
 function chainable(fn) {
   return function(...args) {
     // use an instance with no parent to prevent upwards reflection
-    let results = fn.apply(this.only(), args);
+    let target = this.only ? this.only() : this;
+    let results = fn.apply(target, args);
 
     // return orphaned children to their parent
     if (isSameType(this, results && results.__parent__)) {

--- a/src/utils/parent-chainable.js
+++ b/src/utils/parent-chainable.js
@@ -33,8 +33,7 @@ function isSameType(a, b) {
 function chainable(fn) {
   return function(...args) {
     // use an instance with no parent to prevent upwards reflection
-    let target = this.only ? this.only() : this;
-    let results = fn.apply(target, args);
+    let results = fn.apply(this.only(), args);
 
     // return orphaned children to their parent
     if (isSameType(this, results && results.__parent__)) {
@@ -92,7 +91,7 @@ export default function makeParentChainable(instance) {
         let { value, get } = descriptor;
 
         // do not include the constructor or non-configurable descriptors
-        if (key === 'constructor' ||
+        if (key === 'constructor' || key === '$root' ||
             descriptor.configurable === false) {
           return acc;
         }


### PR DESCRIPTION
## Purpose

This PR addresses an issue discovered while getting BigTest to work with Angular. At this point, it's not clear if it's Angular/Webpack specific or a bug in Interactor. The problem occurs when you have interactor:

```js
@interactor
class AppInteractor {
  static defaultScope = 'app-root';

  message = scoped('[data-test-message]', {
    text: text()
  });
}
let app = new AppInteractor();
```

Trying to access `app.message.isPresent` or `app.message.text` causes an exception saying that `this.only` is not a function. 

## Method

I'm only calling `this.only` is `this.only` is present, otherwise use `this` as target for the interactor invocation.

## TODO

- [x] ~Figure out how reproduce it in tests~ (it'll require typescript setup) 